### PR TITLE
Added extensions when Task result is a raw Element

### DIFF
--- a/Sources/RequestDL/Modifiers/Modifiers.Decode.swift
+++ b/Sources/RequestDL/Modifiers/Modifiers.Decode.swift
@@ -58,7 +58,7 @@ extension Modifiers {
     }
 }
 
-extension Task where Element == TaskResult<Data> {
+extension Task<TaskResult<Data>> {
 
     /**
      Returns a new instance of `ModifiedTask` that applies the `Decode` modifier to the original
@@ -87,7 +87,7 @@ extension Task where Element == TaskResult<Data> {
     }
 }
 
-extension Task where Element == Data {
+extension Task<Data> {
 
     /**
      Returns a new instance of `ModifiedTask` that applies the `Decode` modifier to the original

--- a/Sources/RequestDL/Modifiers/Modifiers.KeyPath.swift
+++ b/Sources/RequestDL/Modifiers/Modifiers.KeyPath.swift
@@ -64,7 +64,7 @@ extension Modifiers {
     }
 }
 
-extension Task where Element == TaskResult<Data> {
+extension Task<TaskResult<Data>> {
 
     /**
      Returns a new `ModifiedTask` instance that applies the `KeyPath` modifier to the task.
@@ -87,7 +87,7 @@ extension Task where Element == TaskResult<Data> {
     }
 }
 
-extension Task where Element == Data {
+extension Task<Data> {
 
     /**
      Returns a new `ModifiedTask` instance that applies the `KeyPath` modifier to the task.

--- a/Sources/RequestDL/Modifiers/Modifiers.KeyPath.swift
+++ b/Sources/RequestDL/Modifiers/Modifiers.KeyPath.swift
@@ -19,12 +19,20 @@ extension Modifiers {
          .keyPath(\.data)
      ```
      */
-    public struct KeyPath<Content: Task>: TaskModifier where Content.Element == TaskResult<Data> {
+    public struct KeyPath<Content: Task>: TaskModifier {
 
         let keyPath: String
+        private let data: (Content.Element) -> Data
+        private let element: (Content.Element, Data) -> Content.Element
 
-        init(_ keyPath: Swift.KeyPath<AbstractKeyPath, String>) {
+        fileprivate init(
+            keyPath: Swift.KeyPath<AbstractKeyPath, String>,
+            data: @escaping (Content.Element) -> Data,
+            element: @escaping (Content.Element, Data) -> Content.Element
+        ) {
             self.keyPath = AbstractKeyPath()[keyPath: keyPath]
+            self.data = data
+            self.element = element
         }
 
         /**
@@ -34,12 +42,12 @@ extension Modifiers {
 
          - Returns: A `TaskResult` containing the extracted sub-value.
          */
-        public func task(_ task: Content) async throws -> TaskResult<Data> {
+        public func task(_ task: Content) async throws -> Content.Element {
             let result = try await task.result()
 
             guard
                 let dictionary = try JSONSerialization.jsonObject(
-                    with: result.data,
+                    with: data(result),
                     options: []
                 ) as? [String: Any]
             else { throw KeyPathInvalidDataError() }
@@ -48,13 +56,10 @@ extension Modifiers {
                 throw KeyPathNotFound(keyPath: keyPath)
             }
 
-            return .init(
-                response: result.response,
-                data: try JSONSerialization.data(
-                    withJSONObject: value,
-                    options: .fragmentsAllowed
-                )
-            )
+            return try element(result, JSONSerialization.data(
+                withJSONObject: value,
+                options: .fragmentsAllowed
+            ))
         }
     }
 }
@@ -69,6 +74,33 @@ extension Task where Element == TaskResult<Data> {
      - Returns: A new `ModifiedTask` instance that applies the `KeyPath` modifier to the task.
      */
     public func keyPath(_ keyPath: KeyPath<AbstractKeyPath, String>) -> ModifiedTask<Modifiers.KeyPath<Self>> {
-        modify(Modifiers.KeyPath(keyPath))
+        modify(Modifiers.KeyPath(
+            keyPath: keyPath,
+            data: \.data,
+            element: {
+                TaskResult(
+                    response: $0.response,
+                    data: $1
+                )
+            }
+        ))
+    }
+}
+
+extension Task where Element == Data {
+
+    /**
+     Returns a new `ModifiedTask` instance that applies the `KeyPath` modifier to the task.
+
+     - Parameter keyPath: The key path to extract the sub-value from the data.
+
+     - Returns: A new `ModifiedTask` instance that applies the `KeyPath` modifier to the task.
+     */
+    public func keyPath(_ keyPath: KeyPath<AbstractKeyPath, String>) -> ModifiedTask<Modifiers.KeyPath<Self>> {
+        modify(Modifiers.KeyPath(
+            keyPath: keyPath,
+            data: { $0 },
+            element: { $1 }
+        ))
     }
 }

--- a/Tests/RequestDLTests/Interceptors/InterceptorsLoggerTests.swift
+++ b/Tests/RequestDLTests/Interceptors/InterceptorsLoggerTests.swift
@@ -7,22 +7,87 @@ import XCTest
 
 final class InterceptorsLoggerTests: XCTestCase {
 
-    func testConsole() async throws {
+    func testConsoleTaskResult() async throws {
         // Given
-        var outputLog = false
+        let data = Data("Hello World!".utf8)
+        var strings = [String]()
 
-        Print.replace {
-            outputLog = true
-            Print.restoreRaise()
-            print($0, separator: $1, terminator: $2)
+        Print.replace { items, separator, _ in
+            strings.append(
+                items
+                    .map { "\($0)" }
+                    .joined(separator: separator)
+            )
         }
 
         // When
-        _ = try await MockedTask(data: Data.init)
+        defer { Print.restoreRaise() }
+
+        let result = try await MockedTask { data }
             .logInConsole(true)
             .result()
 
         // Then
-        XCTAssertTrue(outputLog)
+        XCTAssertEqual(strings, [
+            "[RequestDL] Response: \(result.response)",
+            "[RequestDL] Data: \(String(data: data, encoding: .utf8) ?? "")"
+        ])
+    }
+
+    func testConsoleData() async throws {
+        // Given
+        let data = Data("Hello World!".utf8)
+        var strings = [String]()
+
+        Print.replace { items, separator, _ in
+            strings.append(
+                items
+                    .map { "\($0)" }
+                    .joined(separator: separator)
+            )
+        }
+
+        // When
+        defer { Print.restoreRaise() }
+
+        _ = try await MockedTask { data }
+            .extractPayload()
+            .logInConsole(true)
+            .result()
+
+        // Then
+        XCTAssertEqual(strings, [
+            "[RequestDL] Success: \(String(data: data, encoding: .utf8) ?? "")"
+        ])
+    }
+
+    func testConsoleDecoded() async throws {
+        // Given
+        let value = "Hello World!"
+        var strings = [String]()
+
+        Print.replace { items, separator, _ in
+            strings.append(
+                items
+                    .map { "\($0)" }
+                    .joined(separator: separator)
+            )
+        }
+
+        // When
+        defer { Print.restoreRaise() }
+
+        let data = try JSONEncoder().encode(value)
+
+        _ = try await MockedTask { data }
+            .decode(String.self)
+            .extractPayload()
+            .logInConsole(true)
+            .result()
+
+        // Then
+        XCTAssertEqual(strings, [
+            "[RequestDL] Success: \(value)"
+        ])
     }
 }

--- a/Tests/RequestDLTests/Modifiers/ModifiersDecodeTests.swift
+++ b/Tests/RequestDLTests/Modifiers/ModifiersDecodeTests.swift
@@ -103,31 +103,19 @@ final class ModifiersDecodeTests: XCTestCase {
         )
     }
 
-    func testEmptyDictionary() async throws {
+    func testArrayOfIntegersInData() async throws {
         // Given
-        let emptyData = Data()
+        let array = Array(0..<10)
 
         // When
-        let result = try await MockedTask { emptyData }
-            .decode([Int: Int].self)
+        let data = try JSONEncoder().encode(array)
+
+        let result = try await MockedTask { data }
             .extractPayload()
-            .result()
-
-        // Given
-        XCTAssertEqual(result, [:])
-    }
-
-    func testEmptyArray() async throws {
-        // Given
-        let emptyData = Data()
-
-        // When
-        let result = try await MockedTask { emptyData }
             .decode([Int].self)
-            .extractPayload()
             .result()
 
-        // Given
-        XCTAssertEqual(result, [])
+        // Then
+        XCTAssertEqual(array, result)
     }
 }

--- a/Tests/RequestDLTests/Modifiers/ModifiersKeyPathTests.swift
+++ b/Tests/RequestDLTests/Modifiers/ModifiersKeyPathTests.swift
@@ -38,4 +38,37 @@ final class ModifiersKeyPathTests: XCTestCase {
         XCTAssertTrue(keyPathNotFound)
     }
 
+    func testKeyPathInData() async throws {
+        // Given
+        let data = Data("{ \"key\": true }".utf8)
+
+        // When
+        let result = try await MockedTask { data }
+            .extractPayload()
+            .keyPath(\.key)
+            .result()
+
+        // Then
+        XCTAssertEqual(result, Data("true".utf8))
+    }
+
+    func testWrongKeyPathInData() async throws {
+        // Given
+        let data = Data("{ \"key\": true }".utf8)
+        var keyPathNotFound = false
+
+        // When
+        do {
+            _ = try await MockedTask { data }
+                .extractPayload()
+                .keyPath(\.items)
+                .result()
+        } catch is KeyPathNotFound {
+            keyPathNotFound = true
+        } catch { throw error }
+
+        // Then
+        XCTAssertTrue(keyPathNotFound)
+    }
+
 }


### PR DESCRIPTION
# Pull Request Template

## Description

The necessary extensions were implemented according to the feature proposal details in this PR. With this update, the methods `decode(_:decoder:)`, `logInConsole(_:)`, and `keyPath(_:)` now directly support Data objects.

Fixes #12

### 🚨 Breaking Changes

Previously, within the decode modifier, there was a rule that if the resulting data was empty, the modifier would complete it to force a successful decode operation. This has been removed, and it is now the developer's responsibility to handle this case.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added/updated necessary comments/documentation.
