### PR TITLE
Add `Modifiers.ConvertBytesToData`

### DIFF
--- a/Sources/RequestDL/Modifiers/Modifiers.ConvertBytesToData.swift
+++ b/Sources/RequestDL/Modifiers/Modifiers.ConvertBytesToData.swift
@@ -1,0 +1,101 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+@available(iOS 15, tvOS 15, watchOS 15, macOS 12, *)
+extension Modifiers {
+
+    /**
+     A modifier to convert `URLSession.AsyncBytes` to `Data` type.
+
+     Use this modifier to convert the bytes returned by a task that produces `URLSession.AsyncBytes`
+     to `Data` type.
+
+     Example:
+
+     ```swift
+     func getData() async throws -> Data {
+         try await BytesTask {
+             BaseURL("https://example.com")
+         }
+         .convertBytesToData()
+         .extractPayload()
+         .result()
+     }
+     ```
+
+     - Note: This modifier is available in iOS 15.0+, tvOS 15.0+, watchOS 15.0+, and macOS 12.0+.
+     */
+    public struct ConvertBytesToData<Content: Task, Output>: TaskModifier {
+
+        private let bytes: (Content.Element) -> URLSession.AsyncBytes
+        private let element: (Content.Element, Data) -> Output
+
+        fileprivate init(
+            bytes: @escaping (Content.Element) -> URLSession.AsyncBytes,
+            element: @escaping (Content.Element, Data) -> Output
+        ) {
+            self.bytes = bytes
+            self.element = element
+        }
+
+        /**
+          Returns a task that converts the bytes returned by a task that produces `URLSession.AsyncBytes` to `Data` type.
+
+          - Parameter task: The task that produces `URLSession.AsyncBytes`.
+          - Throws: An error if the conversion fails.
+          - Returns: The converted data.
+          */
+        public func task(_ task: Content) async throws -> Output {
+            let result = try await task.result()
+
+            var data = Data()
+
+            for try await byte in bytes(result) {
+                data.append(byte)
+            }
+
+            return element(result, data)
+        }
+    }
+}
+
+@available(iOS 15, tvOS 15, watchOS 15, macOS 12, *)
+extension Task<TaskResult<URLSession.AsyncBytes>> {
+
+    /**
+     Returns a modified task that converts the bytes returned by a task that produces `TaskResult<URLSession.AsyncBytes>`
+     to `TaskResult<Data>` type.
+
+     - Returns: A modified task that produces `TaskResult<Data>`.
+     */
+    public func convertBytesToData() -> ModifiedTask<Modifiers.ConvertBytesToData<Self, TaskResult<Data>>> {
+        modify(Modifiers.ConvertBytesToData(
+            bytes: \.data,
+            element: {
+                TaskResult(
+                    response: $0.response,
+                    data: $1
+                )
+            }
+        ))
+    }
+}
+
+@available(iOS 15, tvOS 15, watchOS 15, macOS 12, *)
+extension Task<URLSession.AsyncBytes> {
+
+    /**
+     Returns a modified task that converts the bytes returned by a task that produces `URLSession.AsyncBytes` to `Data` type.
+
+     - Returns: A modified task that produces `Data`.
+     */
+    public func convertBytesToData() -> ModifiedTask<Modifiers.ConvertBytesToData<Self, Data>> {
+        modify(Modifiers.ConvertBytesToData(
+            bytes: { $0 },
+            element: { $1 }
+        ))
+    }
+}

--- a/Sources/RequestDL/Modifiers/Modifiers.ConvertBytesToData.swift
+++ b/Sources/RequestDL/Modifiers/Modifiers.ConvertBytesToData.swift
@@ -42,7 +42,8 @@ extension Modifiers {
         }
 
         /**
-          Returns a task that converts the bytes returned by a task that produces `URLSession.AsyncBytes` to `Data` type.
+          Returns a task that converts the bytes returned by a task that produces
+         `URLSession.AsyncBytes` to `Data` type.
 
           - Parameter task: The task that produces `URLSession.AsyncBytes`.
           - Throws: An error if the conversion fails.
@@ -66,8 +67,8 @@ extension Modifiers {
 extension Task<TaskResult<URLSession.AsyncBytes>> {
 
     /**
-     Returns a modified task that converts the bytes returned by a task that produces `TaskResult<URLSession.AsyncBytes>`
-     to `TaskResult<Data>` type.
+     Returns a modified task that converts the bytes returned by a task that produces
+     `TaskResult<URLSession.AsyncBytes>` to `TaskResult<Data>` type.
 
      - Returns: A modified task that produces `TaskResult<Data>`.
      */
@@ -88,7 +89,8 @@ extension Task<TaskResult<URLSession.AsyncBytes>> {
 extension Task<URLSession.AsyncBytes> {
 
     /**
-     Returns a modified task that converts the bytes returned by a task that produces `URLSession.AsyncBytes` to `Data` type.
+     Returns a modified task that converts the bytes returned by a task that produces
+     `URLSession.AsyncBytes` to `Data` type.
 
      - Returns: A modified task that produces `Data`.
      */

--- a/Tests/RequestDLTests/Modifiers/ModifiersConvertBytesToDataTests.swift
+++ b/Tests/RequestDLTests/Modifiers/ModifiersConvertBytesToDataTests.swift
@@ -1,0 +1,72 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import XCTest
+@testable import RequestDL
+
+#if os(macOS)
+@available(macOS 12, *)
+final class ModifiersConvertBytesToDataTests: XCTestCase {
+
+    func testBytesToData() async throws {
+        // Given
+        let server = try OpenSSL("bytes_task_server_to_data", with: [.der]).certificate()
+        let output = "Hello World"
+
+        // When
+        let openSSLServer = OpenSSLServer(output, certificate: server)
+        try await openSSLServer.start {
+            let server = try server.write(into: .module)
+
+            let data = try await BytesTask {
+                BaseURL("localhost:8080")
+                Path("index")
+
+                if let certificate = server.certificateDEREncodedPath {
+                    ServerTrust(Certificate(
+                        certificate,
+                        in: .module
+                    ))
+                }
+            }
+            .extractPayload()
+            .convertBytesToData()
+            .result()
+
+            // Then
+            XCTAssertEqual(String(data: data, encoding: .utf8), output)
+        }
+    }
+
+    func testBytesToDataBeforeExtractPayload() async throws {
+        // Given
+        let server = try OpenSSL("bytes_task_server_to_data", with: [.der]).certificate()
+        let output = "Hello World"
+
+        // When
+        let openSSLServer = OpenSSLServer(output, certificate: server)
+        try await openSSLServer.start {
+            let server = try server.write(into: .module)
+
+            let data = try await BytesTask {
+                BaseURL("localhost:8080")
+                Path("index")
+
+                if let certificate = server.certificateDEREncodedPath {
+                    ServerTrust(Certificate(
+                        certificate,
+                        in: .module
+                    ))
+                }
+            }
+            .convertBytesToData()
+            .extractPayload()
+            .result()
+
+            // Then
+            XCTAssertEqual(String(data: data, encoding: .utf8), output)
+        }
+    }
+}
+#endif

--- a/Tests/RequestDLTests/Modifiers/ModifiersKeyPathTests.swift
+++ b/Tests/RequestDLTests/Modifiers/ModifiersKeyPathTests.swift
@@ -70,5 +70,4 @@ final class ModifiersKeyPathTests: XCTestCase {
         // Then
         XCTAssertTrue(keyPathNotFound)
     }
-
 }


### PR DESCRIPTION
# Add `Modifiers.ConvertBytesToData`

## Description

This pull request implements the feature proposal that allows developers to convert AsyncBytes to Data using a Task Modifier. With this new feature, developers can easily convert AsyncBytes to Data in a declarative manner, making the code more readable and maintainable.

Fixes #11

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added/updated necessary comments/documentation.
