### PR TITLE
Added throws in Property initialization

### DIFF
--- a/Sources/RequestDL/AnyProperty.swift
+++ b/Sources/RequestDL/AnyProperty.swift
@@ -7,12 +7,12 @@ import Foundation
 /// A type-erasing wrapper that can represent any `Property` instance.
 public struct AnyProperty: Property {
 
-    private let resolver: (Context) async -> Void
+    private let resolver: (Context) async throws -> Void
 
     /// Initializes a new instance of `AnyProperty` with the given property `Content`.
     public init<Content: Property>(_ property: Content) {
         resolver = {
-            await Content.makeProperty(property, $0)
+            try await Content.makeProperty(property, $0)
         }
     }
 
@@ -23,7 +23,7 @@ public struct AnyProperty: Property {
     public static func makeProperty(
         _ property: AnyProperty,
         _ context: Context
-    ) async {
-        await property.resolver(context)
+    ) async throws {
+        try await property.resolver(context)
     }
 }

--- a/Sources/RequestDL/Builder/AsyncProperty.swift
+++ b/Sources/RequestDL/Builder/AsyncProperty.swift
@@ -27,7 +27,7 @@ public struct AsyncProperty<Content: Property>: Property {
 
     public typealias Body = Never
 
-    private let content: () async -> Content
+    private let content: () async throws -> Content
 
     /**
      Initializes with an asynchronous content provided.
@@ -35,7 +35,7 @@ public struct AsyncProperty<Content: Property>: Property {
      - Parameters:
         - content: The content of the request to be built.
      */
-    public init(@PropertyBuilder content: @escaping () async -> Content) {
+    public init(@PropertyBuilder content: @escaping () async throws -> Content) {
         self.content = content
     }
 
@@ -48,7 +48,7 @@ public struct AsyncProperty<Content: Property>: Property {
     public static func makeProperty(
         _ property: Self,
         _ context: Context
-    ) async {
-        await Content.makeProperty(property.content(), context)
+    ) async throws {
+        try await Content.makeProperty(property.content(), context)
     }
 }

--- a/Sources/RequestDL/Builder/AsyncProperty.swift
+++ b/Sources/RequestDL/Builder/AsyncProperty.swift
@@ -16,7 +16,7 @@ import Foundation
      RequestMethod(.get)
 
      AsyncProperty {
-         if let id = await getCurrentUserID() {
+         if let id = try await getCurrentUserID() {
              Path("\(id)")
          }
      }

--- a/Sources/RequestDL/Builder/ForEach.swift
+++ b/Sources/RequestDL/Builder/ForEach.swift
@@ -51,9 +51,9 @@ public struct ForEach<Data: Collection, Content: Property>: Property {
     public static func makeProperty(
         _ property: Self,
         _ context: Context
-    ) async {
+    ) async throws {
         for property in property.data.map(property.map) {
-            await Content.makeProperty(property, context)
+            try await Content.makeProperty(property, context)
         }
     }
 }

--- a/Sources/RequestDL/Builder/Group.swift
+++ b/Sources/RequestDL/Builder/Group.swift
@@ -45,7 +45,7 @@ public struct Group<Content: Property>: Property {
     public static func makeProperty(
         _ property: Self,
         _ context: Context
-    ) async {
-        await Content.makeProperty(property.content, context)
+    ) async throws {
+        try await Content.makeProperty(property.content, context)
     }
 }

--- a/Sources/RequestDL/Builder/PropertyBuilder.swift
+++ b/Sources/RequestDL/Builder/PropertyBuilder.swift
@@ -127,8 +127,8 @@ extension PropertyBuilder {
         _ c1: C1
     ) -> _TupleContent<(C0, C1)> {
         _TupleContent {
-            await C0.makeProperty(c0, $0)
-            await C1.makeProperty(c1, $0)
+            try await C0.makeProperty(c0, $0)
+            try await C1.makeProperty(c1, $0)
         }
     }
 
@@ -142,9 +142,9 @@ extension PropertyBuilder {
         _ c2: C2
     ) -> _TupleContent<(C0, C1, C2)> {
         _TupleContent {
-            await C0.makeProperty(c0, $0)
-            await C1.makeProperty(c1, $0)
-            await C2.makeProperty(c2, $0)
+            try await C0.makeProperty(c0, $0)
+            try await C1.makeProperty(c1, $0)
+            try await C2.makeProperty(c2, $0)
         }
     }
 
@@ -160,10 +160,10 @@ extension PropertyBuilder {
         _ c3: C3
     ) -> _TupleContent<(C0, C1, C2, C3)> {
         _TupleContent {
-            await C0.makeProperty(c0, $0)
-            await C1.makeProperty(c1, $0)
-            await C2.makeProperty(c2, $0)
-            await C3.makeProperty(c3, $0)
+            try await C0.makeProperty(c0, $0)
+            try await C1.makeProperty(c1, $0)
+            try await C2.makeProperty(c2, $0)
+            try await C3.makeProperty(c3, $0)
         }
     }
 
@@ -181,11 +181,11 @@ extension PropertyBuilder {
         _ c4: C4
     ) -> _TupleContent<(C0, C1, C2, C3, C4)> {
         _TupleContent {
-            await C0.makeProperty(c0, $0)
-            await C1.makeProperty(c1, $0)
-            await C2.makeProperty(c2, $0)
-            await C3.makeProperty(c3, $0)
-            await C4.makeProperty(c4, $0)
+            try await C0.makeProperty(c0, $0)
+            try await C1.makeProperty(c1, $0)
+            try await C2.makeProperty(c2, $0)
+            try await C3.makeProperty(c3, $0)
+            try await C4.makeProperty(c4, $0)
         }
     }
 
@@ -205,12 +205,12 @@ extension PropertyBuilder {
         _ c5: C5
     ) -> _TupleContent<(C0, C1, C2, C3, C4, C5)> {
         _TupleContent {
-            await C0.makeProperty(c0, $0)
-            await C1.makeProperty(c1, $0)
-            await C2.makeProperty(c2, $0)
-            await C3.makeProperty(c3, $0)
-            await C4.makeProperty(c4, $0)
-            await C5.makeProperty(c5, $0)
+            try await C0.makeProperty(c0, $0)
+            try await C1.makeProperty(c1, $0)
+            try await C2.makeProperty(c2, $0)
+            try await C3.makeProperty(c3, $0)
+            try await C4.makeProperty(c4, $0)
+            try await C5.makeProperty(c5, $0)
         }
     }
 
@@ -232,13 +232,13 @@ extension PropertyBuilder {
         _ c6: C6
     ) -> _TupleContent<(C0, C1, C2, C3, C4, C5, C6)> {
         _TupleContent {
-            await C0.makeProperty(c0, $0)
-            await C1.makeProperty(c1, $0)
-            await C2.makeProperty(c2, $0)
-            await C3.makeProperty(c3, $0)
-            await C4.makeProperty(c4, $0)
-            await C5.makeProperty(c5, $0)
-            await C6.makeProperty(c6, $0)
+            try await C0.makeProperty(c0, $0)
+            try await C1.makeProperty(c1, $0)
+            try await C2.makeProperty(c2, $0)
+            try await C3.makeProperty(c3, $0)
+            try await C4.makeProperty(c4, $0)
+            try await C5.makeProperty(c5, $0)
+            try await C6.makeProperty(c6, $0)
         }
     }
 
@@ -262,14 +262,14 @@ extension PropertyBuilder {
         _ c7: C7
     ) -> _TupleContent<(C0, C1, C2, C3, C4, C5, C6, C7)> {
         _TupleContent {
-            await C0.makeProperty(c0, $0)
-            await C1.makeProperty(c1, $0)
-            await C2.makeProperty(c2, $0)
-            await C3.makeProperty(c3, $0)
-            await C4.makeProperty(c4, $0)
-            await C5.makeProperty(c5, $0)
-            await C6.makeProperty(c6, $0)
-            await C7.makeProperty(c7, $0)
+            try await C0.makeProperty(c0, $0)
+            try await C1.makeProperty(c1, $0)
+            try await C2.makeProperty(c2, $0)
+            try await C3.makeProperty(c3, $0)
+            try await C4.makeProperty(c4, $0)
+            try await C5.makeProperty(c5, $0)
+            try await C6.makeProperty(c6, $0)
+            try await C7.makeProperty(c7, $0)
         }
     }
 }

--- a/Sources/RequestDL/Builder/_ConditionalContent.swift
+++ b/Sources/RequestDL/Builder/_ConditionalContent.swift
@@ -30,12 +30,12 @@ public struct _ConditionalContent<
     public static func makeProperty(
         _ property: Self,
         _ context: Context
-    ) async {
+    ) async throws {
         switch property.option {
         case .first(let property):
-            await TrueProperty.makeProperty(property, context)
+            try await TrueProperty.makeProperty(property, context)
         case .second(let property):
-            await FalseProperty.makeProperty(property, context)
+            try await FalseProperty.makeProperty(property, context)
         }
     }
 }

--- a/Sources/RequestDL/Builder/_OptionalContent.swift
+++ b/Sources/RequestDL/Builder/_OptionalContent.swift
@@ -23,9 +23,9 @@ public struct _OptionalContent<Content: Property>: Property {
     public static func makeProperty(
         _ property: Self,
         _ context: Context
-    ) async {
+    ) async throws {
         if let content = property.content {
-            await Content.makeProperty(content, context)
+            try await Content.makeProperty(content, context)
         }
     }
 }

--- a/Sources/RequestDL/Builder/_TupleContent.swift
+++ b/Sources/RequestDL/Builder/_TupleContent.swift
@@ -8,9 +8,9 @@ import Foundation
 /// to be used directly by clients of this framework.
 public struct _TupleContent<T>: Property {
 
-    private let transformHandler: (Context) async -> Void
+    private let transformHandler: (Context) async throws -> Void
 
-    init(transform: @escaping (Context) async -> Void) {
+    init(transform: @escaping (Context) async throws -> Void) {
         self.transformHandler = transform
     }
 
@@ -23,7 +23,7 @@ public struct _TupleContent<T>: Property {
     public static func makeProperty(
         _ property: Self,
         _ context: Context
-    ) async {
-        await property.transformHandler(context)
+    ) async throws {
+        try await property.transformHandler(context)
     }
 }

--- a/Sources/RequestDL/Form/FormGroup.swift
+++ b/Sources/RequestDL/Form/FormGroup.swift
@@ -45,7 +45,7 @@ public struct FormGroup<Content: Property>: Property {
     public static func makeProperty(
         _ property: Self,
         _ context: Context
-    ) async {
+    ) async throws {
         let node = Node(
             root: context.root,
             object: EmptyObject(property),
@@ -53,7 +53,7 @@ public struct FormGroup<Content: Property>: Property {
         )
 
         let newContext = Context(node)
-        await Content.makeProperty(property.content, newContext)
+        try await Content.makeProperty(property.content, newContext)
 
         let parameters = newContext
             .findCollection(FormObject.self)

--- a/Sources/RequestDL/Headers/HeaderGroup.swift
+++ b/Sources/RequestDL/Headers/HeaderGroup.swift
@@ -43,7 +43,7 @@ public struct HeaderGroup<Content: Property>: Property {
     public static func makeProperty(
         _ property: Self,
         _ context: Context
-    ) async {
+    ) async throws {
         let node = Node(
             root: context.root,
             object: EmptyObject(property),
@@ -51,7 +51,7 @@ public struct HeaderGroup<Content: Property>: Property {
         )
 
         let newContext = Context(node)
-        await Content.makeProperty(property.parameter, newContext)
+        try await Content.makeProperty(property.parameter, newContext)
 
         let parameters = newContext.findCollection(Headers.Object.self).map {
             ($0.key, $0.value)

--- a/Sources/RequestDL/Headers/Headers.swift
+++ b/Sources/RequestDL/Headers/Headers.swift
@@ -20,12 +20,12 @@ extension Headers {
             self.next = next
         }
 
-        func makeProperty(_ make: Make) {
+        func makeProperty(_ make: Make) async throws {
             let value = "\(value)"
             if !value.isEmpty {
                 make.request.setValue(value, forHTTPHeaderField: key)
             }
-            next?.makeProperty(make)
+            try await next?.makeProperty(make)
         }
     }
 }

--- a/Sources/RequestDL/PrimitiveProperty.swift
+++ b/Sources/RequestDL/PrimitiveProperty.swift
@@ -16,7 +16,7 @@ extension PrimitiveProperty {
     public static func makeProperty(
         _ property: Self,
         _ context: Context
-    ) async {
+    ) async throws {
         let node = Node(
             root: context.root,
             object: property.makeObject(),
@@ -29,6 +29,6 @@ extension PrimitiveProperty {
             return
         }
 
-        await Body.makeProperty(property.body, newContext)
+        try await Body.makeProperty(property.body, newContext)
     }
 }

--- a/Sources/RequestDL/Property.swift
+++ b/Sources/RequestDL/Property.swift
@@ -40,13 +40,13 @@ public protocol Property {
     var body: Body { get }
 
     /// This method is used internally and should not be called directly.
-    static func makeProperty(_ property: Self, _ context: Context) async
+    static func makeProperty(_ property: Self, _ context: Context) async throws
 }
 
 extension Property {
 
     /// This method is used internally and should not be called directly.
-    public static func makeProperty(_ property: Self, _ context: Context) async {
+    public static func makeProperty(_ property: Self, _ context: Context) async throws {
         let node = Node(
             root: context.root,
             object: EmptyObject(property),
@@ -54,6 +54,6 @@ extension Property {
         )
 
         let newContext = context.append(node)
-        await Body.makeProperty(property.body, newContext)
+        try await Body.makeProperty(property.body, newContext)
     }
 }

--- a/Sources/RequestDL/Query/QueryGroup.swift
+++ b/Sources/RequestDL/Query/QueryGroup.swift
@@ -43,7 +43,7 @@ public struct QueryGroup<Content: Property>: Property {
     public static func makeProperty(
         _ property: Self,
         _ context: Context
-    ) async {
+    ) async throws {
         let node = Node(
             root: context.root,
             object: EmptyObject(property),
@@ -51,7 +51,7 @@ public struct QueryGroup<Content: Property>: Property {
         )
 
         let newContext = Context(node)
-        await Content.makeProperty(property.content, newContext)
+        try await Content.makeProperty(property.content, newContext)
 
         let parameters = newContext.findCollection(Query.Object.self).map {
             ($0.key, $0.value)

--- a/Sources/RequestDL/Task/BytesTask.swift
+++ b/Sources/RequestDL/Task/BytesTask.swift
@@ -61,7 +61,7 @@ extension BytesTask {
     */
     public func result() async throws -> TaskResult<URLSession.AsyncBytes> {
         let delegate = DelegateProxy()
-        let (session, request) = await Resolver(content).make(delegate)
+        let (session, request) = try await Resolver(content).make(delegate)
 
         defer { session.finishTasksAndInvalidate() }
 

--- a/Sources/RequestDL/Task/DataTask.swift
+++ b/Sources/RequestDL/Task/DataTask.swift
@@ -53,7 +53,7 @@ extension DataTask {
      */
     public func result() async throws -> TaskResult<Data> {
         let delegate = DelegateProxy()
-        let (session, request) = await Resolver(content).make(delegate)
+        let (session, request) = try await Resolver(content).make(delegate)
 
         defer { session.finishTasksAndInvalidate() }
 

--- a/Sources/RequestDL/Task/DownloadTask.swift
+++ b/Sources/RequestDL/Task/DownloadTask.swift
@@ -37,7 +37,7 @@ extension DownloadTask {
      */
     public func result() async throws -> TaskResult<URL> {
         let delegate = DelegateProxy()
-        let (session, request) = await Resolver(content).make(delegate)
+        let (session, request) = try await Resolver(content).make(delegate)
 
         defer { session.finishTasksAndInvalidate() }
 

--- a/Sources/RequestDL/Tree/Context.swift
+++ b/Sources/RequestDL/Tree/Context.swift
@@ -79,15 +79,15 @@ extension Context {
 
 extension Context {
 
-    private static func make(_ make: Make, in node: NodeType) {
-        node.fetchObject()?.makeProperty(make)
+    private static func make(_ make: Make, in node: NodeType) async throws {
+        try await node.fetchObject()?.makeProperty(make)
 
         for node in node.children {
-            self.make(make, in: node)
+            try await self.make(make, in: node)
         }
     }
 
-    func make(_ make: Make) {
-        Self.make(make, in: root)
+    func make(_ make: Make) async throws {
+        try await Self.make(make, in: root)
     }
 }

--- a/Sources/RequestDL/Tree/NodeObject.swift
+++ b/Sources/RequestDL/Tree/NodeObject.swift
@@ -6,5 +6,5 @@ import Foundation
 
 protocol NodeObject {
 
-    func makeProperty(_ make: Make)
+    func makeProperty(_ make: Make) async throws
 }

--- a/Sources/RequestDL/Tree/Resolver.swift
+++ b/Sources/RequestDL/Tree/Resolver.swift
@@ -12,14 +12,14 @@ struct Resolver<Content: Property> {
         self.content = content
     }
 
-    private func resolve() async -> Context {
+    private func resolve() async throws  -> Context {
         let context = Context(RootNode())
-        await Content.makeProperty(content, context)
+        try await Content.makeProperty(content, context)
         return context
     }
 
-    func make(_ delegate: DelegateProxy) async -> (URLSession, URLRequest) {
-        let context = await resolve()
+    func make(_ delegate: DelegateProxy) async throws -> (URLSession, URLRequest) {
+        let context = try await resolve()
 
         guard let object = context.find(BaseURL.Object.self) else {
             fatalError(
@@ -37,7 +37,7 @@ struct Resolver<Content: Property> {
             delegate: delegate
         )
 
-        context.make(make)
+        try await context.make(make)
 
         let session = URLSession(
             configuration: make.configuration,
@@ -51,8 +51,8 @@ struct Resolver<Content: Property> {
 
 extension Resolver {
 
-    func debugPrint() async {
-        let context = await resolve()
+    func debugPrint() async throws {
+        let context = try await resolve()
         context.debug()
     }
 }

--- a/Tests/RequestDLTests/AnyPropertyTests.swift
+++ b/Tests/RequestDLTests/AnyPropertyTests.swift
@@ -12,7 +12,7 @@ final class AnyPropertyTests: XCTestCase {
         let property = Query(123, forKey: "number")
 
         // When
-        let (_, request) = await resolve(TestProperty {
+        let (_, request) = try await resolve(TestProperty {
             BaseURL("localhost")
             AnyProperty(property)
         })

--- a/Tests/RequestDLTests/Builder/AsyncPropertyTests.swift
+++ b/Tests/RequestDLTests/Builder/AsyncPropertyTests.swift
@@ -16,7 +16,7 @@ final class AsyncPropertyTests: XCTestCase {
         }
 
         // When
-        let (_, request) = await resolve(TestProperty {
+        let (_, request) = try await resolve(TestProperty {
             AsyncProperty {
                 if let apiKey = await apiKey {
                     Authorization(.bearer, token: apiKey)

--- a/Tests/RequestDLTests/Builder/EmptyPropertyTests.swift
+++ b/Tests/RequestDLTests/Builder/EmptyPropertyTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 final class EmptyPropertyTests: XCTestCase {
 
-    func testEmptyBuilder() async {
+    func testEmptyBuilder() async throws {
         // Given
         @PropertyBuilder
         var property: some Property {
@@ -16,13 +16,13 @@ final class EmptyPropertyTests: XCTestCase {
         }
 
         // When
-        _ = await resolve(TestProperty(property))
+        _ = try await resolve(TestProperty(property))
 
         // Then
         XCTAssertTrue(property is EmptyProperty)
     }
 
-    func testEmptyExplicitBuilder() async {
+    func testEmptyExplicitBuilder() async throws {
         // Given
         @PropertyBuilder
         var property: some Property {
@@ -30,7 +30,7 @@ final class EmptyPropertyTests: XCTestCase {
         }
 
         // When
-        _ = await resolve(TestProperty(property))
+        _ = try await resolve(TestProperty(property))
 
         // Then
         XCTAssertTrue(property is EmptyProperty)

--- a/Tests/RequestDLTests/Builder/ForEachTests.swift
+++ b/Tests/RequestDLTests/Builder/ForEachTests.swift
@@ -7,12 +7,12 @@ import XCTest
 
 final class ForEachTests: XCTestCase {
 
-    func testForEach() async {
+    func testForEach() async throws {
         // Given
         let paths = ["api", "v1", "users"]
 
         // When
-        let (_, request) = await resolve(TestProperty {
+        let (_, request) = try await resolve(TestProperty {
             BaseURL("localhost")
             ForEach(paths) { path in
                 Path(path)

--- a/Tests/RequestDLTests/Builder/GroupTests.swift
+++ b/Tests/RequestDLTests/Builder/GroupTests.swift
@@ -7,20 +7,20 @@ import XCTest
 
 final class GroupTests: XCTestCase {
 
-    func testSingleGroup() async {
+    func testSingleGroup() async throws {
         // Given
         let property = Group {
             BaseURL("google.com")
         }
 
         // When
-        let (_, request) = await resolve(TestProperty(property))
+        let (_, request) = try await resolve(TestProperty(property))
 
         // Then
         XCTAssertEqual(request.url?.absoluteString, "https://google.com")
     }
 
-    func testMultipleGroup() async {
+    func testMultipleGroup() async throws {
         // Given
         let property = Group {
             BaseURL("google.com")
@@ -29,7 +29,7 @@ final class GroupTests: XCTestCase {
         }
 
         // When
-        let (_, request) = await resolve(TestProperty(property))
+        let (_, request) = try await resolve(TestProperty(property))
 
         // Then
         XCTAssertEqual(

--- a/Tests/RequestDLTests/Builder/PropertyBuilderTests.swift
+++ b/Tests/RequestDLTests/Builder/PropertyBuilderTests.swift
@@ -15,7 +15,7 @@ final class PropertyBuilderTests: XCTestCase {
         }
 
         // When
-        let (_, request) = await resolve(TestProperty(property))
+        let (_, request) = try await resolve(TestProperty(property))
 
         // Then
         XCTAssertTrue(property is Headers.ContentType)
@@ -32,7 +32,7 @@ final class PropertyBuilderTests: XCTestCase {
         }
 
         // When
-        let (_, request) = await resolve(TestProperty(property))
+        let (_, request) = try await resolve(TestProperty(property))
 
         // Then
         print(type(of: property))
@@ -50,7 +50,7 @@ final class PropertyBuilderTests: XCTestCase {
         }
 
         // When
-        let (_, request) = await resolve(TestProperty(property))
+        let (_, request) = try await resolve(TestProperty(property))
 
         // Then
         print(type(of: property))

--- a/Tests/RequestDLTests/Builder/_ConditionalContentTests.swift
+++ b/Tests/RequestDLTests/Builder/_ConditionalContentTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 final class _ConditionalContentTests: XCTestCase {
 
-    func testConditionalFirstBuilder() async {
+    func testConditionalFirstBuilder() async throws {
         // Given
         let chooseFirst = true
 
@@ -21,7 +21,7 @@ final class _ConditionalContentTests: XCTestCase {
         }
 
         // When
-        let (_, request) = await resolve(result)
+        let (_, request) = try await resolve(result)
 
         // Then
         XCTAssertTrue(result is _ConditionalContent<BaseURL, Headers.Origin>)
@@ -29,7 +29,7 @@ final class _ConditionalContentTests: XCTestCase {
         XCTAssertNil(request.allHTTPHeaderFields)
     }
 
-    func testConditionalSecondBuilder() async {
+    func testConditionalSecondBuilder() async throws {
         // Given
         let chooseFirst = false
 
@@ -43,7 +43,7 @@ final class _ConditionalContentTests: XCTestCase {
         }
 
         // When
-        let (_, request) = await resolve(result)
+        let (_, request) = try await resolve(result)
 
         // Then
         XCTAssertTrue(result is _ConditionalContent<Headers.Origin, BaseURL>)

--- a/Tests/RequestDLTests/Builder/_OptionalContentTests.swift
+++ b/Tests/RequestDLTests/Builder/_OptionalContentTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 final class _OptionalContentTests: XCTestCase {
 
-    func testConditionActiveBuilder() async {
+    func testConditionActiveBuilder() async throws {
         // Given
         let applyCondition = true
 
@@ -19,7 +19,7 @@ final class _OptionalContentTests: XCTestCase {
         }
 
         // When
-        let (_, request) = await resolve(result)
+        let (_, request) = try await resolve(result)
 
         // Then
         XCTAssertTrue(result is _OptionalContent<BaseURL>)
@@ -27,7 +27,7 @@ final class _OptionalContentTests: XCTestCase {
         XCTAssertNil(request.allHTTPHeaderFields)
     }
 
-    func testConditionDisableBuilder() async {
+    func testConditionDisableBuilder() async throws {
         // Given
         let applyCondition = false
 
@@ -39,7 +39,7 @@ final class _OptionalContentTests: XCTestCase {
         }
 
         // When
-        let (_, request) = await resolve(TestProperty(result))
+        let (_, request) = try await resolve(TestProperty(result))
 
         // Then
         XCTAssertTrue(result is _OptionalContent<BaseURL>)

--- a/Tests/RequestDLTests/Builder/_TupleContentTests.swift
+++ b/Tests/RequestDLTests/Builder/_TupleContentTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 final class _TupleContentTests: XCTestCase {
 
-    func testTupleTwoElementsBuilder() async {
+    func testTupleTwoElementsBuilder() async throws {
         // Given
         @PropertyBuilder
         var result: some Property {
@@ -16,7 +16,7 @@ final class _TupleContentTests: XCTestCase {
         }
 
         // When
-        let (_, request) = await resolve(result)
+        let (_, request) = try await resolve(result)
 
         // Then
         XCTAssertTrue(result is _TupleContent<(
@@ -28,7 +28,7 @@ final class _TupleContentTests: XCTestCase {
         XCTAssertEqual(request.value(forHTTPHeaderField: "Origin"), "https://apple.com")
     }
 
-    func testTupleThreeElementsBuilder() async {
+    func testTupleThreeElementsBuilder() async throws {
         // Given
         @PropertyBuilder
         var result: some Property {
@@ -38,7 +38,7 @@ final class _TupleContentTests: XCTestCase {
         }
 
         // When
-        let (_, request) = await resolve(result)
+        let (_, request) = try await resolve(result)
 
         // Then
         XCTAssertTrue(result is _TupleContent<(
@@ -52,7 +52,7 @@ final class _TupleContentTests: XCTestCase {
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
     }
 
-    func testTupleFourElementsBuilder() async {
+    func testTupleFourElementsBuilder() async throws {
         // Given
         @PropertyBuilder
         var result: some Property {
@@ -63,7 +63,7 @@ final class _TupleContentTests: XCTestCase {
         }
 
         // When
-        let (_, request) = await resolve(result)
+        let (_, request) = try await resolve(result)
 
         // Then
         XCTAssertTrue(result is _TupleContent<(
@@ -78,7 +78,7 @@ final class _TupleContentTests: XCTestCase {
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
     }
 
-    func testTupleFiveElementsBuilder() async {
+    func testTupleFiveElementsBuilder() async throws {
         // Given
         @PropertyBuilder
         var result: some Property {
@@ -90,7 +90,7 @@ final class _TupleContentTests: XCTestCase {
         }
 
         // When
-        let (_, request) = await resolve(result)
+        let (_, request) = try await resolve(result)
 
         // Then
         XCTAssertTrue(result is _TupleContent<(
@@ -110,7 +110,7 @@ final class _TupleContentTests: XCTestCase {
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
     }
 
-    func testTupleSixElementsBuilder() async {
+    func testTupleSixElementsBuilder() async throws {
         // Given
         @PropertyBuilder
         var result: some Property {
@@ -123,7 +123,7 @@ final class _TupleContentTests: XCTestCase {
         }
 
         // When
-        let (session, request) = await resolve(result)
+        let (session, request) = try await resolve(result)
 
         // Then
         XCTAssertTrue(result is _TupleContent<(
@@ -147,7 +147,7 @@ final class _TupleContentTests: XCTestCase {
         XCTAssertEqual(session.configuration.timeoutIntervalForRequest, 40)
     }
 
-    func testTupleSevenElementsBuilder() async {
+    func testTupleSevenElementsBuilder() async throws {
         // Given
         @PropertyBuilder
         var result: some Property {
@@ -161,7 +161,7 @@ final class _TupleContentTests: XCTestCase {
         }
 
         // When
-        let (session, request) = await resolve(result)
+        let (session, request) = try await resolve(result)
 
         // Then
         XCTAssertTrue(result is _TupleContent<(
@@ -186,7 +186,7 @@ final class _TupleContentTests: XCTestCase {
         XCTAssertEqual(session.configuration.timeoutIntervalForRequest, 40)
     }
 
-    func testTupleEightElementsBuilder() async {
+    func testTupleEightElementsBuilder() async throws {
         // Given
         @PropertyBuilder
         var result: some Property {
@@ -201,7 +201,7 @@ final class _TupleContentTests: XCTestCase {
         }
 
         // When
-        let (session, request) = await resolve(result)
+        let (session, request) = try await resolve(result)
 
         // Then
         XCTAssertTrue(result is _TupleContent<(

--- a/Tests/RequestDLTests/Form/FormDataTests.swift
+++ b/Tests/RequestDLTests/Form/FormDataTests.swift
@@ -24,7 +24,7 @@ final class FormDataTests: XCTestCase {
         )
 
         // When
-        let (_, request) = await resolve(TestProperty(property))
+        let (_, request) = try await resolve(TestProperty(property))
 
         let contentTypeHeader = request.value(forHTTPHeaderField: "Content-Type")
         let boundary = MultipartFormParser.extractBoundary(contentTypeHeader) ?? "nil"
@@ -62,7 +62,7 @@ final class FormDataTests: XCTestCase {
         )
 
         // When
-        let (_, request) = await resolve(TestProperty(property))
+        let (_, request) = try await resolve(TestProperty(property))
 
         let contentTypeHeader = request.value(forHTTPHeaderField: "Content-Type")
         let boundary = MultipartFormParser.extractBoundary(contentTypeHeader) ?? "nil"

--- a/Tests/RequestDLTests/Form/FormFileTests.swift
+++ b/Tests/RequestDLTests/Form/FormFileTests.swift
@@ -24,7 +24,7 @@ final class FormFileTests: XCTestCase {
         )
 
         // When
-        let (_, request) = await resolve(TestProperty(property))
+        let (_, request) = try await resolve(TestProperty(property))
 
         let contentTypeHeader = request.value(forHTTPHeaderField: "Content-Type")
         let boundary = MultipartFormParser.extractBoundary(contentTypeHeader) ?? "nil"
@@ -68,7 +68,7 @@ final class FormFileTests: XCTestCase {
         )
 
         // When
-        let (_, request) = await resolve(TestProperty(property))
+        let (_, request) = try await resolve(TestProperty(property))
 
         let contentTypeHeader = request.value(forHTTPHeaderField: "Content-Type")
         let boundary = MultipartFormParser.extractBoundary(contentTypeHeader) ?? "nil"

--- a/Tests/RequestDLTests/Form/FormGroupTests.swift
+++ b/Tests/RequestDLTests/Form/FormGroupTests.swift
@@ -18,7 +18,7 @@ final class FormGroupTests: XCTestCase {
         }
 
         // When
-        let (_, request) = await resolve(TestProperty(property))
+        let (_, request) = try await resolve(TestProperty(property))
 
         let contentTypeHeader = request.value(forHTTPHeaderField: "Content-Type")
         let boundary = MultipartFormParser.extractBoundary(contentTypeHeader) ?? "nil"
@@ -73,7 +73,7 @@ final class FormGroupTests: XCTestCase {
         }
 
         // When
-        let (_, request) = await resolve(TestProperty(property))
+        let (_, request) = try await resolve(TestProperty(property))
 
         let contentTypeHeader = request.value(forHTTPHeaderField: "Content-Type")
         let boundary = MultipartFormParser.extractBoundary(contentTypeHeader) ?? "nil"
@@ -140,7 +140,7 @@ final class FormGroupTests: XCTestCase {
         }
 
         // When
-        let (_, request) = await resolve(TestProperty(property))
+        let (_, request) = try await resolve(TestProperty(property))
 
         let contentTypeHeader = request.value(forHTTPHeaderField: "Content-Type")
         let boundary = MultipartFormParser.extractBoundary(contentTypeHeader) ?? "nil"

--- a/Tests/RequestDLTests/Form/FormValueTests.swift
+++ b/Tests/RequestDLTests/Form/FormValueTests.swift
@@ -14,7 +14,7 @@ final class FormValueTests: XCTestCase {
         let property = FormValue(value, forKey: key)
 
         // When
-        let (_, request) = await resolve(TestProperty(property))
+        let (_, request) = try await resolve(TestProperty(property))
 
         let contentTypeHeader = request.value(forHTTPHeaderField: "Content-Type")
         let boundary = MultipartFormParser.extractBoundary(contentTypeHeader) ?? "nil"

--- a/Tests/RequestDLTests/Headers/Authorization/AuthorizationTests.swift
+++ b/Tests/RequestDLTests/Headers/Authorization/AuthorizationTests.swift
@@ -7,22 +7,22 @@ import XCTest
 
 final class AuthorizationTests: XCTestCase {
 
-    func testAuthorizationWithTypeAndToken() async {
+    func testAuthorizationWithTypeAndToken() async throws {
         // Given
         let auth = Authorization(.bearer, token: "myToken")
 
         // When
-        let (_, request) = await resolve(TestProperty(auth))
+        let (_, request) = try await resolve(TestProperty(auth))
 
         // Then
         XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer myToken")
     }
 
-    func testAuthorizationWithUsernameAndPassword() async {
+    func testAuthorizationWithUsernameAndPassword() async throws {
         let auth = Authorization(username: "myUser", password: "myPassword")
 
         // When
-        let (_, request) = await resolve(TestProperty(auth))
+        let (_, request) = try await resolve(TestProperty(auth))
 
         // Then
         XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Basic bXlVc2VyOm15UGFzc3dvcmQ=")

--- a/Tests/RequestDLTests/Headers/HeaderGroupTests.swift
+++ b/Tests/RequestDLTests/Headers/HeaderGroupTests.swift
@@ -9,7 +9,7 @@ final class HeaderGroupTests: XCTestCase {
 
     func testHeaderGroupWithEmptyValue() async throws {
         let property = TestProperty(HeaderGroup {})
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertTrue(request.allHTTPHeaderFields?.isEmpty ?? true)
     }
 
@@ -21,7 +21,7 @@ final class HeaderGroupTests: XCTestCase {
             "xxx-api-key": "password"
         ]))
 
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
 
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
         XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "text/html")
@@ -37,7 +37,7 @@ final class HeaderGroupTests: XCTestCase {
             Headers.Any("password", forKey: "xxx-api-key")
         })
 
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
 
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "text/javascript")
         XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/json")

--- a/Tests/RequestDLTests/Headers/HeadersAcceptTests.swift
+++ b/Tests/RequestDLTests/Headers/HeadersAcceptTests.swift
@@ -7,105 +7,105 @@ import XCTest
 
 final class HeadersAcceptTests: XCTestCase {
 
-    func testHeadersJsonAccept() async {
+    func testHeadersJsonAccept() async throws {
         let property = TestProperty(Headers.Accept(.json))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/json")
     }
 
-    func testHeadersXmlAccept() async {
+    func testHeadersXmlAccept() async throws {
         let property = TestProperty(Headers.Accept(.xml))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/xml")
     }
 
-    func testHeadersFormDataAccept() async {
+    func testHeadersFormDataAccept() async throws {
         let property = TestProperty(Headers.Accept(.formData))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "form-data")
     }
 
-    func testHeadersFormURLEncodedAccept() async {
+    func testHeadersFormURLEncodedAccept() async throws {
         let property = TestProperty(Headers.Accept(.formURLEncoded))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/x-www-form-urlencoded")
     }
 
-    func testHeadersTextAccept() async {
+    func testHeadersTextAccept() async throws {
         let property = TestProperty(Headers.Accept(.text))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "text/plain")
     }
 
-    func testHeadersHtmlAccept() async {
+    func testHeadersHtmlAccept() async throws {
         let property = TestProperty(Headers.Accept(.html))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "text/html")
     }
 
-    func testHeadersCssAccept() async {
+    func testHeadersCssAccept() async throws {
         let property = TestProperty(Headers.Accept(.css))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "text/css")
     }
 
-    func testHeadersJavascriptAccept() async {
+    func testHeadersJavascriptAccept() async throws {
         let property = TestProperty(Headers.Accept(.javascript))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "text/javascript")
     }
 
-    func testHeadersGifAccept() async {
+    func testHeadersGifAccept() async throws {
         let property = TestProperty(Headers.Accept(.gif))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "image/gif")
     }
 
-    func testHeadersPngAccept() async {
+    func testHeadersPngAccept() async throws {
         let property = TestProperty(Headers.Accept(.png))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "image/png")
     }
 
-    func testHeadersJpegAccept() async {
+    func testHeadersJpegAccept() async throws {
         let property = TestProperty(Headers.Accept(.jpeg))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "image/jpeg")
     }
 
-    func testHeadersBmpAccept() async {
+    func testHeadersBmpAccept() async throws {
         let property = TestProperty(Headers.Accept(.bmp))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "image/bmp")
     }
 
-    func testHeadersWebpAccept() async {
+    func testHeadersWebpAccept() async throws {
         let property = TestProperty(Headers.Accept(.webp))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "image/webp")
     }
 
-    func testHeadersMidiAccept() async {
+    func testHeadersMidiAccept() async throws {
         let property = TestProperty(Headers.Accept(.midi))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "audio/midi")
     }
 
-    func testHeadersMpegAccept() async {
+    func testHeadersMpegAccept() async throws {
         let property = TestProperty(Headers.Accept(.mpeg))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "audio/mpeg")
     }
 
-    func testHeadersWavAccept() async {
+    func testHeadersWavAccept() async throws {
         let property = TestProperty(Headers.Accept(.wav))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "audio/wav")
     }
 
-    func testHeadersPdfAccept() async {
+    func testHeadersPdfAccept() async throws {
         let property = TestProperty(Headers.Accept(.pdf))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/pdf")
     }
 

--- a/Tests/RequestDLTests/Headers/HeadersAnyTests.swift
+++ b/Tests/RequestDLTests/Headers/HeadersAnyTests.swift
@@ -7,19 +7,19 @@ import XCTest
 
 final class HeadersAnyTests: XCTestCase {
 
-    func testSingleHeaderAny() async {
+    func testSingleHeaderAny() async throws {
         let property = TestProperty(Headers.Any("password", forKey: "xxx-api-key"))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "xxx-api-key"), "password")
     }
 
-    func testHeadersAny() async {
+    func testHeadersAny() async throws {
         let property = TestProperty {
             Headers.Any("text/html", forKey: "Accept")
             Headers.Any("gzip", forKey: "Content-Encoding")
         }
 
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
 
         XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "text/html")
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Encoding"), "gzip")

--- a/Tests/RequestDLTests/Headers/HeadersCacheTests.swift
+++ b/Tests/RequestDLTests/Headers/HeadersCacheTests.swift
@@ -25,7 +25,7 @@ final class HeadersCacheTests: XCTestCase {
         XCTAssertFalse(cache.isImmutable)
     }
 
-    func testInitializationWithPolicy() async {
+    func testInitializationWithPolicy() async throws {
         // Given
         let policy = URLRequest.CachePolicy.reloadIgnoringLocalCacheData
         let memoryCapacity = 10_000_000
@@ -38,7 +38,7 @@ final class HeadersCacheTests: XCTestCase {
             diskCapacity: diskCapacity
         )
 
-        let (session, request) = await resolve(TestProperty(cache))
+        let (session, request) = try await resolve(TestProperty(cache))
 
         // Then
         XCTAssertTrue(cache.isCached)
@@ -61,7 +61,7 @@ final class HeadersCacheTests: XCTestCase {
         XCTAssertEqual(session.configuration.urlCache?.diskCapacity, diskCapacity)
     }
 
-    func testModifiedCacheWithAllProperties() async {
+    func testModifiedCacheWithAllProperties() async throws {
         // Given
         let policy = URLRequest.CachePolicy.reloadIgnoringLocalCacheData
         let cache = Headers.Cache(policy)
@@ -82,7 +82,7 @@ final class HeadersCacheTests: XCTestCase {
             .immutable()
 
         // When
-        let (session, request) = await resolve(TestProperty(modifiedCache))
+        let (session, request) = try await resolve(TestProperty(modifiedCache))
 
         // Then
         XCTAssertFalse(modifiedCache.isCached)
@@ -111,13 +111,13 @@ final class HeadersCacheTests: XCTestCase {
         )
     }
 
-    func testPublicCache() async {
+    func testPublicCache() async throws {
         // Given
         let cache = Headers.Cache()
             .public(true)
 
         // When
-        let (_, request) = await resolve(TestProperty(cache))
+        let (_, request) = try await resolve(TestProperty(cache))
 
         // Then
         XCTAssertEqual(request.value(forHTTPHeaderField: "Cache-Control"), "public")

--- a/Tests/RequestDLTests/Headers/HeadersContentLengthTests.swift
+++ b/Tests/RequestDLTests/Headers/HeadersContentLengthTests.swift
@@ -9,7 +9,7 @@ final class HeadersContentLengthTests: XCTestCase {
 
     func testContentLength() async throws {
         let property = TestProperty(Headers.ContentLength(1_000_000))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Length"), "1000000")
     }
 

--- a/Tests/RequestDLTests/Headers/HeadersContentTypeTests.swift
+++ b/Tests/RequestDLTests/Headers/HeadersContentTypeTests.swift
@@ -7,105 +7,105 @@ import XCTest
 
 final class HeadersContentTypeTests: XCTestCase {
 
-    func testHeadersJsonContentType() async {
+    func testHeadersJsonContentType() async throws {
         let property = TestProperty(Headers.ContentType(.json))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
     }
 
-    func testHeadersXmlContentType() async {
+    func testHeadersXmlContentType() async throws {
         let property = TestProperty(Headers.ContentType(.xml))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/xml")
     }
 
-    func testHeadersFormDataContentType() async {
+    func testHeadersFormDataContentType() async throws {
         let property = TestProperty(Headers.ContentType(.formData))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "form-data")
     }
 
-    func testHeadersFormURLEncodedContentType() async {
+    func testHeadersFormURLEncodedContentType() async throws {
         let property = TestProperty(Headers.ContentType(.formURLEncoded))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/x-www-form-urlencoded")
     }
 
-    func testHeadersTextContentType() async {
+    func testHeadersTextContentType() async throws {
         let property = TestProperty(Headers.ContentType(.text))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "text/plain")
     }
 
-    func testHeadersHtmlContentType() async {
+    func testHeadersHtmlContentType() async throws {
         let property = TestProperty(Headers.ContentType(.html))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "text/html")
     }
 
-    func testHeadersCssContentType() async {
+    func testHeadersCssContentType() async throws {
         let property = TestProperty(Headers.ContentType(.css))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "text/css")
     }
 
-    func testHeadersJavascriptContentType() async {
+    func testHeadersJavascriptContentType() async throws {
         let property = TestProperty(Headers.ContentType(.javascript))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "text/javascript")
     }
 
-    func testHeadersGifContentType() async {
+    func testHeadersGifContentType() async throws {
         let property = TestProperty(Headers.ContentType(.gif))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "image/gif")
     }
 
-    func testHeadersPngContentType() async {
+    func testHeadersPngContentType() async throws {
         let property = TestProperty(Headers.ContentType(.png))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "image/png")
     }
 
-    func testHeadersJpegContentType() async {
+    func testHeadersJpegContentType() async throws {
         let property = TestProperty(Headers.ContentType(.jpeg))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "image/jpeg")
     }
 
-    func testHeadersBmpContentType() async {
+    func testHeadersBmpContentType() async throws {
         let property = TestProperty(Headers.ContentType(.bmp))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "image/bmp")
     }
 
-    func testHeadersWebpContentType() async {
+    func testHeadersWebpContentType() async throws {
         let property = TestProperty(Headers.ContentType(.webp))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "image/webp")
     }
 
-    func testHeadersMidiContentType() async {
+    func testHeadersMidiContentType() async throws {
         let property = TestProperty(Headers.ContentType(.midi))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "audio/midi")
     }
 
-    func testHeadersMpegContentType() async {
+    func testHeadersMpegContentType() async throws {
         let property = TestProperty(Headers.ContentType(.mpeg))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "audio/mpeg")
     }
 
-    func testHeadersWavContentType() async {
+    func testHeadersWavContentType() async throws {
         let property = TestProperty(Headers.ContentType(.wav))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "audio/wav")
     }
 
-    func testHeadersPdfContentType() async {
+    func testHeadersPdfContentType() async throws {
         let property = TestProperty(Headers.ContentType(.pdf))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/pdf")
     }
 

--- a/Tests/RequestDLTests/Headers/HeadersHostTests.swift
+++ b/Tests/RequestDLTests/Headers/HeadersHostTests.swift
@@ -9,13 +9,13 @@ final class HeadersHostTests: XCTestCase {
 
     func testHost() async throws {
         let property = TestProperty(Headers.Host("google.com"))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Host"), "google.com")
     }
 
     func testHostWithPort() async throws {
         let property = TestProperty(Headers.Host("google.com", port: "8080"))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Host"), "google.com:8080")
     }
 

--- a/Tests/RequestDLTests/Headers/HeadersOriginTests.swift
+++ b/Tests/RequestDLTests/Headers/HeadersOriginTests.swift
@@ -9,13 +9,13 @@ final class HeadersOriginTests: XCTestCase {
 
     func testHost() async throws {
         let property = TestProperty(Headers.Origin("google.com"))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Origin"), "google.com")
     }
 
     func testHostWithPort() async throws {
         let property = TestProperty(Headers.Origin("google.com", port: "8080"))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Origin"), "google.com:8080")
     }
 

--- a/Tests/RequestDLTests/Headers/HeadersRefererTests.swift
+++ b/Tests/RequestDLTests/Headers/HeadersRefererTests.swift
@@ -9,19 +9,19 @@ final class HeadersRefererTests: XCTestCase {
 
     func testReferer() async throws {
         let property = TestProperty(Headers.Referer("https://www.example.com/"))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Referer"), "https://www.example.com/")
     }
 
     func testRefererWithHTML() async throws {
         let property = TestProperty(Headers.Referer("https://www.example.com/page1.html"))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Referer"), "https://www.example.com/page1.html")
     }
 
     func testRefererWithPathAndQuery() async throws {
         let property = TestProperty(Headers.Referer("https://www.google.com/search?q=apple"))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Referer"), "https://www.google.com/search?q=apple")
     }
 

--- a/Tests/RequestDLTests/Headers/HeadersTests.swift
+++ b/Tests/RequestDLTests/Headers/HeadersTests.swift
@@ -15,7 +15,7 @@ final class HeadersTests: XCTestCase {
             Headers.Any("password", forKey: "xxx-api-key")
         }
 
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
 
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "text/javascript")
         XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/json")
@@ -23,7 +23,7 @@ final class HeadersTests: XCTestCase {
         XCTAssertEqual(request.value(forHTTPHeaderField: "xxx-api-key"), "password")
     }
 
-    func testCollisionHeaders() async {
+    func testCollisionHeaders() async throws {
         let property = TestProperty {
             Headers.ContentType(.javascript)
             Headers.ContentType(.webp)
@@ -32,14 +32,14 @@ final class HeadersTests: XCTestCase {
             Headers.Any("password123", forKey: "xxx-api-key")
         }
 
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
 
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "image/webp")
         XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "image/jpeg")
         XCTAssertEqual(request.value(forHTTPHeaderField: "xxx-api-key"), "password123")
     }
 
-    func testCollisionHeadersWithGroup() async {
+    func testCollisionHeadersWithGroup() async throws {
         let property = TestProperty {
             Headers.ContentType(.javascript)
             Headers.Accept(.jpeg)
@@ -51,14 +51,14 @@ final class HeadersTests: XCTestCase {
             }
         }
 
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
 
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "image/webp")
         XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "image/jpeg")
         XCTAssertEqual(request.value(forHTTPHeaderField: "xxx-api-key"), "password123")
     }
 
-    func testCombinedHeadersWithGroup() async {
+    func testCombinedHeadersWithGroup() async throws {
         let property = TestProperty {
             Headers.Host("localhost", port: "8080")
 
@@ -71,7 +71,7 @@ final class HeadersTests: XCTestCase {
             Headers.Origin("google.com")
         }
 
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
 
         XCTAssertEqual(request.value(forHTTPHeaderField: "Host"), "localhost:8080")
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "image/webp")
@@ -80,7 +80,7 @@ final class HeadersTests: XCTestCase {
         XCTAssertEqual(request.value(forHTTPHeaderField: "Origin"), "google.com")
     }
 
-    func testInvalidGroup() async {
+    func testInvalidGroup() async throws {
         // Given
         let property = TestProperty {
             BaseURL("localhost")
@@ -90,7 +90,7 @@ final class HeadersTests: XCTestCase {
         }
 
         // When
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
 
         // Then
         XCTAssertEqual(request.url?.absoluteString, "https://localhost")

--- a/Tests/RequestDLTests/Method/RequestMethodTests.swift
+++ b/Tests/RequestDLTests/Method/RequestMethodTests.swift
@@ -9,55 +9,55 @@ final class RequestMethodTests: XCTestCase {
 
     func testGetHTTPMethod() async throws {
         let property = TestProperty(RequestMethod(.get))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.httpMethod, "GET")
     }
 
     func testHeadHTTPMethod() async throws {
         let property = TestProperty(RequestMethod(.head))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.httpMethod, "HEAD")
     }
 
     func testPostHTTPMethod() async throws {
         let property = TestProperty(RequestMethod(.post))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.httpMethod, "POST")
     }
 
     func testPutHTTPMethod() async throws {
         let property = TestProperty(RequestMethod(.put))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.httpMethod, "PUT")
     }
 
     func testDeleteHTTPMethod() async throws {
         let property = TestProperty(RequestMethod(.delete))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.httpMethod, "DELETE")
     }
 
     func testConnectHTTPMethod() async throws {
         let property = TestProperty(RequestMethod(.connect))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.httpMethod, "CONNECT")
     }
 
     func testOptionsHTTPMethod() async throws {
         let property = TestProperty(RequestMethod(.options))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.httpMethod, "OPTIONS")
     }
 
     func testTraceHTTPMethod() async throws {
         let property = TestProperty(RequestMethod(.trace))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.httpMethod, "TRACE")
     }
 
     func testPatchHTTPMethod() async throws {
         let property = TestProperty(RequestMethod(.patch))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         XCTAssertEqual(request.httpMethod, "PATCH")
     }
 

--- a/Tests/RequestDLTests/Payload/PayloadTests.swift
+++ b/Tests/RequestDLTests/Payload/PayloadTests.swift
@@ -23,7 +23,7 @@ final class PayloadTests: XCTestCase {
 
         // When
         let property = TestProperty(Payload(dictionary, options: options))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         let expectedPayload = _DictionaryPayload(dictionary, options: options)
 
         // Then
@@ -37,7 +37,7 @@ final class PayloadTests: XCTestCase {
 
         // When
         let property = TestProperty(Payload(foo, using: encoding))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         let expectedPayload = _StringPayload(foo, using: encoding)
 
         // Then
@@ -50,7 +50,7 @@ final class PayloadTests: XCTestCase {
 
         // When
         let property = TestProperty(Payload(data))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         let expectedPayload = _DataPayload(data)
 
         // Then
@@ -71,7 +71,7 @@ final class PayloadTests: XCTestCase {
 
         // When
         let property = TestProperty(Payload(mock, encoder: encoder))
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
         let expectedPayload = _EncodablePayload(mock, encoder: encoder)
         let expectedMock = try decoder.decode(Mock.self, from: expectedPayload.data)
 

--- a/Tests/RequestDLTests/Query/QueryGroupTests.swift
+++ b/Tests/RequestDLTests/Query/QueryGroupTests.swift
@@ -15,7 +15,7 @@ final class QueryGroupTests: XCTestCase {
         }
 
         // When
-        let (_, request) = await resolve(TestProperty {
+        let (_, request) = try await resolve(TestProperty {
             BaseURL("localhost")
             property
         })
@@ -40,7 +40,7 @@ final class QueryGroupTests: XCTestCase {
         }
 
         // When
-        let (_, request) = await resolve(TestProperty {
+        let (_, request) = try await resolve(TestProperty {
             BaseURL("localhost")
             property
         })

--- a/Tests/RequestDLTests/Query/QueryTests.swift
+++ b/Tests/RequestDLTests/Query/QueryTests.swift
@@ -12,7 +12,7 @@ final class QueryTests: XCTestCase {
         let property = Query(123, forKey: "number")
 
         // When
-        let (_, request) = await resolve(TestProperty {
+        let (_, request) = try await resolve(TestProperty {
             BaseURL("localhost")
             property
         })
@@ -32,7 +32,7 @@ final class QueryTests: XCTestCase {
         }
 
         // When
-        let (_, request) = await resolve(property)
+        let (_, request) = try await resolve(property)
 
         // Then
         XCTAssertEqual(

--- a/Tests/RequestDLTests/Representable/URLRequestRepresentableTests.swift
+++ b/Tests/RequestDLTests/Representable/URLRequestRepresentableTests.swift
@@ -19,7 +19,7 @@ final class URLRequestRepresentableTests: XCTestCase {
         let property = URLRequestMock()
 
         // When
-        let (_, request) = await resolve(TestProperty(property))
+        let (_, request) = try await resolve(TestProperty(property))
 
         // Then
         XCTAssertEqual(request.value(forHTTPHeaderField: "api_key"), "password")

--- a/Tests/RequestDLTests/Representable/URLSessionConfigurationRepresentableTests.swift
+++ b/Tests/RequestDLTests/Representable/URLSessionConfigurationRepresentableTests.swift
@@ -21,7 +21,7 @@ final class URLSessionConfigurationRepresentableTests: XCTestCase {
         let property = URLSessionConfigurationMock()
 
         // When
-        let (session, _) = await resolve(TestProperty(property))
+        let (session, _) = try await resolve(TestProperty(property))
 
         // Then
         XCTAssertEqual(session.configuration.timeoutIntervalForRequest, 15)

--- a/Tests/RequestDLTests/RequestBackgroundAdaptorTests.swift
+++ b/Tests/RequestDLTests/RequestBackgroundAdaptorTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 final class RequestBackgroundAdaptorTests: XCTestCase {
 
-    func testBackgroundAdaptor() async {
+    func testBackgroundAdaptor() async throws {
         // Given
         let backgroundAdaptor = RequestBackgroundAdaptor()
         let backgroundService = BackgroundService.shared

--- a/Tests/RequestDLTests/SessionTests.swift
+++ b/Tests/RequestDLTests/SessionTests.swift
@@ -14,7 +14,7 @@ final class SessionTests: XCTestCase {
         let configuration = URLSessionConfiguration.default
 
         // When
-        let (session, _) = await resolve(TestProperty { property })
+        let (session, _) = try await resolve(TestProperty { property })
 
         // Then
         XCTAssertEqual(
@@ -138,7 +138,7 @@ final class SessionTests: XCTestCase {
         let configuration = URLSessionConfiguration.ephemeral
 
         // When
-        let (session, _) = await resolve(TestProperty { property })
+        let (session, _) = try await resolve(TestProperty { property })
 
         // Then
         XCTAssertEqual(
@@ -263,7 +263,7 @@ final class SessionTests: XCTestCase {
         let configuration = URLSessionConfiguration.background(withIdentifier: backgroundID)
 
         // When
-        let (session, _) = await resolve(TestProperty { property })
+        let (session, _) = try await resolve(TestProperty { property })
 
         // Then
         XCTAssertEqual(
@@ -381,12 +381,12 @@ final class SessionTests: XCTestCase {
         )
     }
 
-    func testNetworkService() async {
+    func testNetworkService() async throws {
         // Given
         let networkService: URLRequest.NetworkServiceType = .video
 
         // When
-        let (session, _) = await resolve(
+        let (session, _) = try await resolve(
             TestProperty {
                 Session(.default)
                     .networkService(networkService)
@@ -400,12 +400,12 @@ final class SessionTests: XCTestCase {
         )
     }
 
-    func testCellularAccessDisabled() async {
+    func testCellularAccessDisabled() async throws {
         // Given
         let cellularAccessDisabled = true
 
         // When
-        let (session, _) = await resolve(
+        let (session, _) = try await resolve(
             TestProperty {
                 Session(.default)
                     .cellularAccessDisabled(cellularAccessDisabled)
@@ -419,12 +419,12 @@ final class SessionTests: XCTestCase {
         )
     }
 
-    func testExpensiveNetworkDisabled() async {
+    func testExpensiveNetworkDisabled() async throws {
         // Given
         let expensiveNetworkDisabled = true
 
         // When
-        let (session, _) = await resolve(
+        let (session, _) = try await resolve(
             TestProperty {
                 Session(.default)
                     .expensiveNetworkDisabled(expensiveNetworkDisabled)
@@ -438,12 +438,12 @@ final class SessionTests: XCTestCase {
         )
     }
 
-    func testConstrainedNetworkDisabled() async {
+    func testConstrainedNetworkDisabled() async throws {
         // Given
         let constrainedNetworkDisabled = true
 
         // When
-        let (session, _) = await resolve(
+        let (session, _) = try await resolve(
             TestProperty {
                 Session(.default)
                     .constrainedNetworkDisabled(constrainedNetworkDisabled)
@@ -457,12 +457,12 @@ final class SessionTests: XCTestCase {
         )
     }
 
-    func testWaitsForConnectivity() async {
+    func testWaitsForConnectivity() async throws {
         // Given
         let waitsForConnectivity = true
 
         // When
-        let (session, _) = await resolve(
+        let (session, _) = try await resolve(
             TestProperty {
                 Session(.default)
                     .waitsForConnectivity(waitsForConnectivity)
@@ -476,12 +476,12 @@ final class SessionTests: XCTestCase {
         )
     }
 
-    func testDiscretionary() async {
+    func testDiscretionary() async throws {
         // Given
         let discretionary = true
 
         // When
-        let (session, _) = await resolve(
+        let (session, _) = try await resolve(
             TestProperty {
                 Session(.default)
                     .discretionary(discretionary)
@@ -495,12 +495,12 @@ final class SessionTests: XCTestCase {
         )
     }
 
-    func testSharedContainerIdentifier() async {
+    func testSharedContainerIdentifier() async throws {
         // Given
         let sharedContainerIdentifier = "unit.test"
 
         // When
-        let (session, _) = await resolve(
+        let (session, _) = try await resolve(
             TestProperty {
                 Session(.default)
                     .sharedContainerIdentifier(sharedContainerIdentifier)
@@ -514,12 +514,12 @@ final class SessionTests: XCTestCase {
         )
     }
 
-    func testSendsLaunchEvents() async {
+    func testSendsLaunchEvents() async throws {
         // Given
         let sendsLaunchEvents = true
 
         // When
-        let (session, _) = await resolve(
+        let (session, _) = try await resolve(
             TestProperty {
                 Session(.default)
                     .sendsLaunchEvents(sendsLaunchEvents)
@@ -533,12 +533,12 @@ final class SessionTests: XCTestCase {
         )
     }
 
-    func testConnectionProxyDictionary() async {
+    func testConnectionProxyDictionary() async throws {
         // Given
         let connectionProxyDictionary = [AnyHashable: Any]()
 
         // When
-        let (session, _) = await resolve(
+        let (session, _) = try await resolve(
             TestProperty {
                 Session(.default)
                     .connectionProxyDictionary(connectionProxyDictionary)
@@ -552,13 +552,13 @@ final class SessionTests: XCTestCase {
         )
     }
 
-    func testProtocolSupported() async {
+    func testProtocolSupported() async throws {
         // Given
         let tlsProtocolSupportedMin = tls_protocol_version_t.TLSv11
         let tlsProtocolSupportedMax = tls_protocol_version_t.TLSv11
 
         // When
-        let (session, _) = await resolve(
+        let (session, _) = try await resolve(
             TestProperty {
                 Session(.default)
                     .tlsProtocolSupported(
@@ -580,12 +580,12 @@ final class SessionTests: XCTestCase {
         )
     }
 
-    func testPipeliningDisabled() async {
+    func testPipeliningDisabled() async throws {
         // Given
         let pipeliningDisabled = false
 
         // When
-        let (session, _) = await resolve(
+        let (session, _) = try await resolve(
             TestProperty {
                 Session(.default)
                     .pipeliningDisabled(pipeliningDisabled)
@@ -599,12 +599,12 @@ final class SessionTests: XCTestCase {
         )
     }
 
-    func testSetCookiesDisabled() async {
+    func testSetCookiesDisabled() async throws {
         // Given
         let setCookiesDisabled = true
 
         // When
-        let (session, _) = await resolve(
+        let (session, _) = try await resolve(
             TestProperty {
                 Session(.default)
                     .setCookiesDisabled(setCookiesDisabled)
@@ -618,12 +618,12 @@ final class SessionTests: XCTestCase {
         )
     }
 
-    func testCookieAcceptPolicy() async {
+    func testCookieAcceptPolicy() async throws {
         // Given
         let cookieAcceptPolicy: HTTPCookie.AcceptPolicy = .never
 
         // When
-        let (session, _) = await resolve(
+        let (session, _) = try await resolve(
             TestProperty {
                 Session(.default)
                     .cookieAcceptPolicy(cookieAcceptPolicy)
@@ -637,12 +637,12 @@ final class SessionTests: XCTestCase {
         )
     }
 
-    func testCookieStorage() async {
+    func testCookieStorage() async throws {
         // Given
         let cookieStorage = HTTPCookieStorage()
 
         // When
-        let (session, _) = await resolve(
+        let (session, _) = try await resolve(
             TestProperty {
                 Session(.default)
                     .cookieStorage(cookieStorage)
@@ -656,12 +656,12 @@ final class SessionTests: XCTestCase {
         )
     }
 
-    func testMaximumConnectionsPerHost() async {
+    func testMaximumConnectionsPerHost() async throws {
         // Given
         let maximumConnectionsPerHost = 5
 
         // When
-        let (session, _) = await resolve(
+        let (session, _) = try await resolve(
             TestProperty {
                 Session(.default)
                     .maximumConnectionsPerHost(maximumConnectionsPerHost)
@@ -675,12 +675,12 @@ final class SessionTests: XCTestCase {
         )
     }
 
-    func testExtendedBackgroundIdleModeDisabled() async {
+    func testExtendedBackgroundIdleModeDisabled() async throws {
         // Given
         let extendedBackgroundIdleModeDisabled = false
 
         // When
-        let (session, _) = await resolve(
+        let (session, _) = try await resolve(
             TestProperty {
                 Session(.default)
                     .extendedBackgroundIdleModeDisabled(extendedBackgroundIdleModeDisabled)
@@ -696,12 +696,12 @@ final class SessionTests: XCTestCase {
 
     #if swift(>=5.7.2)
     @available(iOS 16, macOS 13, watchOS 9, tvOS 16, *)
-    func testValidatesDNSSec() async {
+    func testValidatesDNSSec() async throws {
         // Given
         let validatesDNSSec = true
 
         // When
-        let (session, _) = await resolve(
+        let (session, _) = try await resolve(
             TestProperty {
                 Session(.default)
                     .validatesDNSSec(validatesDNSSec)
@@ -716,12 +716,12 @@ final class SessionTests: XCTestCase {
     }
     #endif
 
-    func testCredentialStorage() async {
+    func testCredentialStorage() async throws {
         // Given
         let credentialStorage = URLCredentialStorage()
 
         // When
-        let (session, _) = await resolve(
+        let (session, _) = try await resolve(
             TestProperty {
                 Session(.default)
                     .credentialStorage(credentialStorage)

--- a/Tests/RequestDLTests/Timeout/TimeoutTests.swift
+++ b/Tests/RequestDLTests/Timeout/TimeoutTests.swift
@@ -7,48 +7,48 @@ import XCTest
 
 final class TimeoutTests: XCTestCase {
 
-    func testRequestTimeout() async {
+    func testRequestTimeout() async throws {
         // Given
         let requestTimeout = Timeout.Source.request
         let timeout = TimeInterval(75)
 
         // When
-        let (session, _) = await resolve(TestProperty(Timeout(timeout, for: requestTimeout)))
+        let (session, _) = try await resolve(TestProperty(Timeout(timeout, for: requestTimeout)))
 
         // Then
         XCTAssertEqual(session.configuration.timeoutIntervalForRequest, timeout)
     }
 
-    func testResourceTimeout() async {
+    func testResourceTimeout() async throws {
         // Given
         let resourceTimeout = Timeout.Source.resource
         let timeout = TimeInterval(1_999)
 
         // When
-        let (session, _) = await resolve(TestProperty(Timeout(timeout, for: resourceTimeout)))
+        let (session, _) = try await resolve(TestProperty(Timeout(timeout, for: resourceTimeout)))
 
         // Then
         XCTAssertEqual(session.configuration.timeoutIntervalForResource, timeout)
     }
 
-    func testAllTimeout() async {
+    func testAllTimeout() async throws {
         // Given
         let requestTimeout = Timeout.Source.all
         let timeout = TimeInterval(75)
 
         // When
-        let (session, _) = await resolve(TestProperty(Timeout(timeout, for: requestTimeout)))
+        let (session, _) = try await resolve(TestProperty(Timeout(timeout, for: requestTimeout)))
 
         // Then
         XCTAssertEqual(session.configuration.timeoutIntervalForRequest, timeout)
         XCTAssertEqual(session.configuration.timeoutIntervalForResource, timeout)
     }
 
-    func testDefaultTimeout() async {
+    func testDefaultTimeout() async throws {
         let defaultConfiguration = URLSessionConfiguration.default
 
         // When
-        let (session, _) = await resolve(TestProperty {})
+        let (session, _) = try await resolve(TestProperty {})
 
         // Then
         XCTAssertEqual(

--- a/Tests/RequestDLTests/URL/BaseURLTests.swift
+++ b/Tests/RequestDLTests/URL/BaseURLTests.swift
@@ -7,142 +7,142 @@ import XCTest
 
 final class BaseURLTests: XCTestCase {
 
-    func testHttpURL() async {
+    func testHttpURL() async throws {
         // Given
         let internetProtocol = InternetProtocol.http
         let host = "google.com"
 
         // When
         let baseURL = BaseURL(internetProtocol, host: host)
-        let (_, request) = await resolve(baseURL)
+        let (_, request) = try await resolve(baseURL)
 
         // Then
         XCTAssertEqual(request.url?.absoluteString, "\(internetProtocol)://\(host)")
     }
 
-    func testHttpsURL() async {
+    func testHttpsURL() async throws {
         // Given
         let internetProtocol = InternetProtocol.https
         let host = "google.com"
 
         // When
         let baseURL = BaseURL(internetProtocol, host: host)
-        let (_, request) = await resolve(baseURL)
+        let (_, request) = try await resolve(baseURL)
 
         // Then
         XCTAssertEqual(request.url?.absoluteString, "\(internetProtocol)://\(host)")
     }
 
-    func testFtpURL() async {
+    func testFtpURL() async throws {
         // Given
         let internetProtocol = InternetProtocol.ftp
         let host = "google.com"
 
         // When
         let baseURL = BaseURL(internetProtocol, host: host)
-        let (_, request) = await resolve(baseURL)
+        let (_, request) = try await resolve(baseURL)
 
         // Then
         XCTAssertEqual(request.url?.absoluteString, "\(internetProtocol)://\(host)")
     }
 
-    func testSmtpURL() async {
+    func testSmtpURL() async throws {
         // Given
         let internetProtocol = InternetProtocol.smtp
         let host = "google.com"
 
         // When
         let baseURL = BaseURL(internetProtocol, host: host)
-        let (_, request) = await resolve(baseURL)
+        let (_, request) = try await resolve(baseURL)
 
         // Then
         XCTAssertEqual(request.url?.absoluteString, "\(internetProtocol)://\(host)")
     }
 
-    func testImapURL() async {
+    func testImapURL() async throws {
         // Given
         let internetProtocol = InternetProtocol.imap
         let host = "google.com"
 
         // When
         let baseURL = BaseURL(internetProtocol, host: host)
-        let (_, request) = await resolve(baseURL)
+        let (_, request) = try await resolve(baseURL)
 
         // Then
         XCTAssertEqual(request.url?.absoluteString, "\(internetProtocol)://\(host)")
     }
 
-    func testPopURL() async {
+    func testPopURL() async throws {
         // Given
         let internetProtocol = InternetProtocol.pop
         let host = "google.com"
 
         // When
         let baseURL = BaseURL(internetProtocol, host: host)
-        let (_, request) = await resolve(baseURL)
+        let (_, request) = try await resolve(baseURL)
 
         // Then
         XCTAssertEqual(request.url?.absoluteString, "\(internetProtocol)://\(host)")
     }
 
-    func testDnsURL() async {
+    func testDnsURL() async throws {
         // Given
         let internetProtocol = InternetProtocol.dns
         let host = "google.com"
 
         // When
         let baseURL = BaseURL(internetProtocol, host: host)
-        let (_, request) = await resolve(baseURL)
+        let (_, request) = try await resolve(baseURL)
 
         // Then
         XCTAssertEqual(request.url?.absoluteString, "\(internetProtocol)://\(host)")
     }
 
-    func testSshURL() async {
+    func testSshURL() async throws {
         // Given
         let internetProtocol = InternetProtocol.ssh
         let host = "google.com"
 
         // When
         let baseURL = BaseURL(internetProtocol, host: host)
-        let (_, request) = await resolve(baseURL)
+        let (_, request) = try await resolve(baseURL)
 
         // Then
         XCTAssertEqual(request.url?.absoluteString, "\(internetProtocol)://\(host)")
     }
 
-    func testTelnetURL() async {
+    func testTelnetURL() async throws {
         // Given
         let internetProtocol = InternetProtocol.telnet
         let host = "google.com"
 
         // When
         let baseURL = BaseURL(internetProtocol, host: host)
-        let (_, request) = await resolve(baseURL)
+        let (_, request) = try await resolve(baseURL)
 
         // Then
         XCTAssertEqual(request.url?.absoluteString, "\(internetProtocol)://\(host)")
     }
 
-    func testDefaultURLWithoutProtocol() async {
+    func testDefaultURLWithoutProtocol() async throws {
         // Given
         let host = "google.com.br"
 
         // When
         let baseURL = BaseURL(host)
-        let (_, request) = await resolve(baseURL)
+        let (_, request) = try await resolve(baseURL)
 
         // Then
         XCTAssertEqual(request.url?.absoluteString, "https://google.com.br")
     }
 
-    func testCollisionBaseURL() async {
+    func testCollisionBaseURL() async throws {
         // Given
         let host1 = "apple.com"
         let host2 = "google.com"
 
         // When
-        let (_, request) = await resolve(TestProperty {
+        let (_, request) = try await resolve(TestProperty {
             BaseURL(.ftp, host: host1)
             BaseURL(host2)
         })

--- a/Tests/RequestDLTests/URL/PathTests.swift
+++ b/Tests/RequestDLTests/URL/PathTests.swift
@@ -7,13 +7,13 @@ import XCTest
 
 final class PathTests: XCTestCase {
 
-    func testSinglePath() async {
+    func testSinglePath() async throws {
         // Given
         let path = "api"
         let host = "google.com"
 
         // When
-        let (_, request) = await resolve(TestProperty {
+        let (_, request) = try await resolve(TestProperty {
             BaseURL(host)
             Path(path)
         })
@@ -25,13 +25,13 @@ final class PathTests: XCTestCase {
         )
     }
 
-    func testSingleInstanceWithMultiplePath() async {
+    func testSingleInstanceWithMultiplePath() async throws {
         // Given
         let path = "api/v1/users/10/detail"
         let host = "google.com"
 
         // When
-        let (_, request) = await resolve(TestProperty {
+        let (_, request) = try await resolve(TestProperty {
             BaseURL(host)
             Path(path)
         })
@@ -43,7 +43,7 @@ final class PathTests: XCTestCase {
         )
     }
 
-    func testMultiplePath() async {
+    func testMultiplePath() async throws {
         // Given
         let path1 = "api"
         let path2 = "v1/"
@@ -52,7 +52,7 @@ final class PathTests: XCTestCase {
         let characterSetRule = CharacterSet(charactersIn: "/")
 
         // When
-        let (_, request) = await resolve(TestProperty {
+        let (_, request) = try await resolve(TestProperty {
             BaseURL(host)
             Path(path1)
             Path(path2)

--- a/Tests/RequestDLTests/Utils/resolve.swift
+++ b/Tests/RequestDLTests/Utils/resolve.swift
@@ -8,6 +8,6 @@ import Foundation
 func resolve<Content: Property>(
     _ content: Content,
     in delegate: DelegateProxy = .init()
-) async -> (URLSession, URLRequest) {
-    await Resolver(content).make(delegate)
+) async throws -> (URLSession, URLRequest) {
+    try await Resolver(content).make(delegate)
 }


### PR DESCRIPTION
## Description

The Pull Request (PR) proposed based on the feature proposal in issue #15 aims to implement a new feature that allows the execution of asynchronous commands that may generate errors during property initialization.

The PR includes an update to the Property protocol declaration, which now allows the `throws` keyword in the `makeProperty` function. This means that developers can now execute code that may generate errors during property initialization.

The PR also includes some updates to the syntax of asynchronous codes that may also generate errors, so that they follow the same syntax as property initialization. This standardization helps make the code more consistent and easy to understand.

With this new feature, developers now have the option to execute code that generates errors during property initialization, improving code robustness and making error debugging easier. This PR has passed unit tests to ensure that the new feature is working correctly.

Fixes #15

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
