### PR TITLE
Renamed readed to read

### DIFF
--- a/Tests/RequestDLTests/Internals/Extensions/Array.UInt8+.swift
+++ b/Tests/RequestDLTests/Internals/Extensions/Array.UInt8+.swift
@@ -10,7 +10,7 @@ extension Array<UInt8> {
     func split(by size: Int) -> [Data] {
         var buffer = Internals.DataBuffer(self)
         var items = [Data]()
-        var readedBytes = 0
+        var readBytes = 0
 
         func nextSize() -> Int {
             if buffer.readableBytes - size < .zero {
@@ -21,7 +21,7 @@ extension Array<UInt8> {
         }
 
         while let data = buffer.readData(nextSize()) {
-            readedBytes += data.count
+            readBytes += data.count
             items.append(data)
         }
 

--- a/Tests/RequestDLTests/Internals/Sources/Buffers/Data/InternalsDataBufferTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Buffers/Data/InternalsDataBufferTests.swift
@@ -70,14 +70,14 @@ class InternalsDataBufferTests: XCTestCase {
         var dataBuffer = Internals.DataBuffer(byteURL)
 
         // When
-        let readedData = dataBuffer.readData(data.count)
+        let readData = dataBuffer.readData(data.count)
 
         // Then
         XCTAssertEqual(dataBuffer.writerIndex, data.count)
         XCTAssertEqual(dataBuffer.readerIndex, data.count)
         XCTAssertEqual(dataBuffer.readableBytes, .zero)
         XCTAssertEqual(dataBuffer.writableBytes, .zero)
-        XCTAssertEqual(readedData, data)
+        XCTAssertEqual(readData, data)
         XCTAssertEqual(dataBuffer.estimatedBytes, data.count)
     }
 
@@ -211,10 +211,10 @@ class InternalsDataBufferTests: XCTestCase {
         let writerIndex = sut1.writerIndex
         let readerIndex = sut1.readerIndex
 
-        let readedData = sut2.readData(data.count)
+        let readData = sut2.readData(data.count)
 
         // Then
-        XCTAssertEqual(readedData, data)
+        XCTAssertEqual(readData, data)
         XCTAssertEqual(writerIndex, data.count)
         XCTAssertEqual(readerIndex, .zero)
         XCTAssertEqual(sut2.writerIndex, data.count)
@@ -235,10 +235,10 @@ class InternalsDataBufferTests: XCTestCase {
         let writerIndex = sut1.writerIndex
         let readerIndex = sut1.readerIndex
 
-        let readedData = sut2.readData(data.count)
+        let readData = sut2.readData(data.count)
 
         // Then
-        XCTAssertEqual(readedData, data)
+        XCTAssertEqual(readData, data)
         XCTAssertEqual(writerIndex, data.count)
         XCTAssertEqual(readerIndex, .zero)
         XCTAssertEqual(sut2.writerIndex, data.count)
@@ -257,16 +257,16 @@ class InternalsDataBufferTests: XCTestCase {
         var sut2 = Internals.DataBuffer(byteURL)
 
         // When
-        let readedData2 = sut2.readData(data.count)
-        let readedData1 = sut1.readData(readSliceIndex)
+        let readData2 = sut2.readData(data.count)
+        let readData1 = sut1.readData(readSliceIndex)
 
         // Then
-        XCTAssertEqual(readedData1, data[0..<readSliceIndex])
+        XCTAssertEqual(readData1, data[0..<readSliceIndex])
         XCTAssertEqual(sut1.writerIndex, data.count)
         XCTAssertEqual(sut1.readableBytes, data.count - readSliceIndex)
         XCTAssertEqual(sut1.writableBytes, .zero)
 
-        XCTAssertEqual(readedData2, data)
+        XCTAssertEqual(readData2, data)
         XCTAssertEqual(sut2.writerIndex, data.count)
         XCTAssertEqual(sut2.readableBytes, .zero)
         XCTAssertEqual(sut2.writableBytes, .zero)
@@ -282,16 +282,16 @@ class InternalsDataBufferTests: XCTestCase {
         var sut2 = Internals.DataBuffer(byteURL)
 
         // When
-        let readedBytes2 = sut2.readBytes(data.count)
-        let readedBytes1 = sut1.readBytes(readSliceIndex)
+        let readBytes2 = sut2.readBytes(data.count)
+        let readBytes1 = sut1.readBytes(readSliceIndex)
 
         // Then
-        XCTAssertEqual(readedBytes1, Array(data[0..<readSliceIndex]))
+        XCTAssertEqual(readBytes1, Array(data[0..<readSliceIndex]))
         XCTAssertEqual(sut1.writerIndex, data.count)
         XCTAssertEqual(sut1.readableBytes, data.count - readSliceIndex)
         XCTAssertEqual(sut1.writableBytes, .zero)
 
-        XCTAssertEqual(readedBytes2, Array(data))
+        XCTAssertEqual(readBytes2, Array(data))
         XCTAssertEqual(sut2.writerIndex, data.count)
         XCTAssertEqual(sut2.readableBytes, .zero)
         XCTAssertEqual(sut2.writableBytes, .zero)
@@ -307,18 +307,18 @@ class InternalsDataBufferTests: XCTestCase {
 
         // When
         sut2.writeData(data)
-        let readedDataBeforeOverride2 = sut2.readData(data.count)
+        let readDataBeforeOverride2 = sut2.readData(data.count)
 
         sut1.writeData(overrideData)
-        let readedData2 = sut1.readData(sut1.readableBytes)
+        let readData2 = sut1.readData(sut1.readableBytes)
 
         sut2.moveReaderIndex(to: .zero)
-        let readedDataAfterOverride2 = sut2.readData(sut2.readableBytes)
+        let readDataAfterOverride2 = sut2.readData(sut2.readableBytes)
 
         // Then
-        XCTAssertEqual(readedDataBeforeOverride2, data)
-        XCTAssertEqual(readedData2, overrideData)
-        XCTAssertEqual(readedDataAfterOverride2, overrideData + data[overrideData.count..<data.count])
+        XCTAssertEqual(readDataBeforeOverride2, data)
+        XCTAssertEqual(readData2, overrideData)
+        XCTAssertEqual(readDataAfterOverride2, overrideData + data[overrideData.count..<data.count])
 
         XCTAssertEqual(sut1.writerIndex, overrideData.count)
         XCTAssertEqual(sut1.readerIndex, overrideData.count)
@@ -383,10 +383,10 @@ class InternalsDataBufferTests: XCTestCase {
         var dataBuffer = Internals.DataBuffer(data)
 
         // When
-        let readedData = dataBuffer.readData(dataBuffer.readableBytes)
+        let readData = dataBuffer.readData(dataBuffer.readableBytes)
 
         // Then
-        XCTAssertEqual(readedData, data)
+        XCTAssertEqual(readData, data)
         XCTAssertEqual(dataBuffer.writerIndex, data.count)
         XCTAssertEqual(dataBuffer.readerIndex, data.count)
         XCTAssertEqual(dataBuffer.readableBytes, .zero)
@@ -399,10 +399,10 @@ class InternalsDataBufferTests: XCTestCase {
         var dataBuffer = Internals.DataBuffer(bytes)
 
         // When
-        let readedBytes = dataBuffer.readBytes(dataBuffer.readableBytes)
+        let readBytes = dataBuffer.readBytes(dataBuffer.readableBytes)
 
         // Then
-        XCTAssertEqual(readedBytes, bytes)
+        XCTAssertEqual(readBytes, bytes)
         XCTAssertEqual(dataBuffer.writerIndex, bytes.count)
         XCTAssertEqual(dataBuffer.readerIndex, bytes.count)
         XCTAssertEqual(dataBuffer.readableBytes, .zero)
@@ -415,10 +415,10 @@ class InternalsDataBufferTests: XCTestCase {
         var dataBuffer = Internals.DataBuffer(string)
 
         // When
-        let readedData = dataBuffer.readData(dataBuffer.readableBytes)
+        let readData = dataBuffer.readData(dataBuffer.readableBytes)
 
         // Then
-        XCTAssertEqual(readedData, Data(string.utf8))
+        XCTAssertEqual(readData, Data(string.utf8))
         XCTAssertEqual(dataBuffer.writerIndex, string.count)
         XCTAssertEqual(dataBuffer.readerIndex, string.count)
         XCTAssertEqual(dataBuffer.readableBytes, .zero)
@@ -431,10 +431,10 @@ class InternalsDataBufferTests: XCTestCase {
         var dataBuffer = Internals.DataBuffer(string)
 
         // When
-        let readedData = dataBuffer.readData(dataBuffer.readableBytes)
+        let readData = dataBuffer.readData(dataBuffer.readableBytes)
 
         // Then
-        XCTAssertEqual(readedData, "\(string)".data(using: .utf8))
+        XCTAssertEqual(readData, "\(string)".data(using: .utf8))
         XCTAssertEqual(dataBuffer.writerIndex, string.utf8CodeUnitCount)
         XCTAssertEqual(dataBuffer.readerIndex, string.utf8CodeUnitCount)
         XCTAssertEqual(dataBuffer.readableBytes, .zero)
@@ -448,11 +448,11 @@ class InternalsDataBufferTests: XCTestCase {
         var sut1 = Internals.DataBuffer(dataBuffer)
 
         // When
-        let readedData = sut1.readData(sut1.readableBytes)
+        let readData = sut1.readData(sut1.readableBytes)
 
         // Then
         XCTAssertEqual(sut1.writerIndex, dataBuffer.writerIndex)
-        XCTAssertEqual(readedData, data)
+        XCTAssertEqual(readData, data)
     }
 
     func testDataBuffer_whenInitFileURL_shouldBeEmpty() async throws {

--- a/Tests/RequestDLTests/Internals/Sources/Buffers/File/InternalsFileBufferTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Buffers/File/InternalsFileBufferTests.swift
@@ -75,14 +75,14 @@ class InternalsFileBufferTests: XCTestCase {
         var fileBuffer = Internals.FileBuffer(fileURL)
 
         // When
-        let readedData = fileBuffer.readData(data.count)
+        let readData = fileBuffer.readData(data.count)
 
         // Then
         XCTAssertEqual(fileBuffer.writerIndex, data.count)
         XCTAssertEqual(fileBuffer.readerIndex, data.count)
         XCTAssertEqual(fileBuffer.readableBytes, .zero)
         XCTAssertEqual(fileBuffer.writableBytes, .zero)
-        XCTAssertEqual(readedData, data)
+        XCTAssertEqual(readData, data)
         XCTAssertEqual(fileBuffer.estimatedBytes, data.count)
     }
 
@@ -216,10 +216,10 @@ class InternalsFileBufferTests: XCTestCase {
         let writerIndex = sut1.writerIndex
         let readerIndex = sut1.readerIndex
 
-        let readedData = sut2.readData(data.count)
+        let readData = sut2.readData(data.count)
 
         // Then
-        XCTAssertEqual(readedData, data)
+        XCTAssertEqual(readData, data)
         XCTAssertEqual(writerIndex, data.count)
         XCTAssertEqual(readerIndex, .zero)
         XCTAssertEqual(sut2.writerIndex, data.count)
@@ -240,10 +240,10 @@ class InternalsFileBufferTests: XCTestCase {
         let writerIndex = sut1.writerIndex
         let readerIndex = sut1.readerIndex
 
-        let readedData = sut2.readData(data.count)
+        let readData = sut2.readData(data.count)
 
         // Then
-        XCTAssertEqual(readedData, data)
+        XCTAssertEqual(readData, data)
         XCTAssertEqual(writerIndex, data.count)
         XCTAssertEqual(readerIndex, .zero)
         XCTAssertEqual(sut2.writerIndex, data.count)
@@ -262,16 +262,16 @@ class InternalsFileBufferTests: XCTestCase {
         var sut2 = Internals.FileBuffer(fileURL)
 
         // When
-        let readedData2 = sut2.readData(data.count)
-        let readedData1 = sut1.readData(readSliceIndex)
+        let readData2 = sut2.readData(data.count)
+        let readData1 = sut1.readData(readSliceIndex)
 
         // Then
-        XCTAssertEqual(readedData1, data[0..<readSliceIndex])
+        XCTAssertEqual(readData1, data[0..<readSliceIndex])
         XCTAssertEqual(sut1.writerIndex, data.count)
         XCTAssertEqual(sut1.readableBytes, data.count - readSliceIndex)
         XCTAssertEqual(sut1.writableBytes, .zero)
 
-        XCTAssertEqual(readedData2, data)
+        XCTAssertEqual(readData2, data)
         XCTAssertEqual(sut2.writerIndex, data.count)
         XCTAssertEqual(sut2.readableBytes, .zero)
         XCTAssertEqual(sut2.writableBytes, .zero)
@@ -287,16 +287,16 @@ class InternalsFileBufferTests: XCTestCase {
         var sut2 = Internals.FileBuffer(fileURL)
 
         // When
-        let readedBytes2 = sut2.readBytes(data.count)
-        let readedBytes1 = sut1.readBytes(readSliceIndex)
+        let readBytes2 = sut2.readBytes(data.count)
+        let readBytes1 = sut1.readBytes(readSliceIndex)
 
         // Then
-        XCTAssertEqual(readedBytes1, Array(data[0..<readSliceIndex]))
+        XCTAssertEqual(readBytes1, Array(data[0..<readSliceIndex]))
         XCTAssertEqual(sut1.writerIndex, data.count)
         XCTAssertEqual(sut1.readableBytes, data.count - readSliceIndex)
         XCTAssertEqual(sut1.writableBytes, .zero)
 
-        XCTAssertEqual(readedBytes2, Array(data))
+        XCTAssertEqual(readBytes2, Array(data))
         XCTAssertEqual(sut2.writerIndex, data.count)
         XCTAssertEqual(sut2.readableBytes, .zero)
         XCTAssertEqual(sut2.writableBytes, .zero)
@@ -312,18 +312,18 @@ class InternalsFileBufferTests: XCTestCase {
 
         // When
         sut2.writeData(data)
-        let readedDataBeforeOverride2 = sut2.readData(data.count)
+        let readDataBeforeOverride2 = sut2.readData(data.count)
 
         sut1.writeData(overrideData)
-        let readedData2 = sut1.readData(sut1.readableBytes)
+        let readData2 = sut1.readData(sut1.readableBytes)
 
         sut2.moveReaderIndex(to: .zero)
-        let readedDataAfterOverride2 = sut2.readData(sut2.readableBytes)
+        let readDataAfterOverride2 = sut2.readData(sut2.readableBytes)
 
         // Then
-        XCTAssertEqual(readedDataBeforeOverride2, data)
-        XCTAssertEqual(readedData2, overrideData)
-        XCTAssertEqual(readedDataAfterOverride2, overrideData + data[overrideData.count..<data.count])
+        XCTAssertEqual(readDataBeforeOverride2, data)
+        XCTAssertEqual(readData2, overrideData)
+        XCTAssertEqual(readDataAfterOverride2, overrideData + data[overrideData.count..<data.count])
 
         XCTAssertEqual(sut1.writerIndex, overrideData.count)
         XCTAssertEqual(sut1.readerIndex, overrideData.count)
@@ -392,10 +392,10 @@ class InternalsFileBufferTests: XCTestCase {
         var fileBuffer = Internals.FileBuffer(data)
 
         // When
-        let readedData = fileBuffer.readData(fileBuffer.readableBytes)
+        let readData = fileBuffer.readData(fileBuffer.readableBytes)
 
         // Then
-        XCTAssertEqual(readedData, data)
+        XCTAssertEqual(readData, data)
         XCTAssertEqual(fileBuffer.writerIndex, data.count)
         XCTAssertEqual(fileBuffer.readerIndex, data.count)
         XCTAssertEqual(fileBuffer.readableBytes, .zero)
@@ -409,10 +409,10 @@ class InternalsFileBufferTests: XCTestCase {
         var fileBuffer = Internals.FileBuffer(BytesSequence(data))
 
         // When
-        let readedBytes = fileBuffer.readBytes(fileBuffer.readableBytes)
+        let readBytes = fileBuffer.readBytes(fileBuffer.readableBytes)
 
         // Then
-        XCTAssertEqual(readedBytes, bytes)
+        XCTAssertEqual(readBytes, bytes)
         XCTAssertEqual(fileBuffer.writerIndex, bytes.count)
         XCTAssertEqual(fileBuffer.readerIndex, bytes.count)
         XCTAssertEqual(fileBuffer.readableBytes, .zero)
@@ -425,10 +425,10 @@ class InternalsFileBufferTests: XCTestCase {
         var fileBuffer = Internals.FileBuffer(string)
 
         // When
-        let readedData = fileBuffer.readData(fileBuffer.readableBytes)
+        let readData = fileBuffer.readData(fileBuffer.readableBytes)
 
         // Then
-        XCTAssertEqual(readedData, Data(string.utf8))
+        XCTAssertEqual(readData, Data(string.utf8))
         XCTAssertEqual(fileBuffer.writerIndex, string.count)
         XCTAssertEqual(fileBuffer.readerIndex, string.count)
         XCTAssertEqual(fileBuffer.readableBytes, .zero)
@@ -441,10 +441,10 @@ class InternalsFileBufferTests: XCTestCase {
         var fileBuffer = Internals.FileBuffer(string)
 
         // When
-        let readedData = fileBuffer.readData(fileBuffer.readableBytes)
+        let readData = fileBuffer.readData(fileBuffer.readableBytes)
 
         // Then
-        XCTAssertEqual(readedData, "\(string)".data(using: .utf8))
+        XCTAssertEqual(readData, "\(string)".data(using: .utf8))
         XCTAssertEqual(fileBuffer.writerIndex, string.utf8CodeUnitCount)
         XCTAssertEqual(fileBuffer.readerIndex, string.utf8CodeUnitCount)
         XCTAssertEqual(fileBuffer.readableBytes, .zero)
@@ -458,11 +458,11 @@ class InternalsFileBufferTests: XCTestCase {
         var sut1 = Internals.FileBuffer(fileBuffer)
 
         // When
-        let readedData = sut1.readData(sut1.readableBytes)
+        let readData = sut1.readData(sut1.readableBytes)
 
         // Then
         XCTAssertEqual(sut1.writerIndex, fileBuffer.writerIndex)
-        XCTAssertEqual(readedData, data)
+        XCTAssertEqual(readData, data)
     }
 
     func testFileBuffer_whenInitByteURL_shouldBeEmpty() async throws {


### PR DESCRIPTION
## Description

This pull request aims to correct a grammatical error in the word "read", which was mistakenly written as "readed", an invalid form.
