### PR TITLE
Renamed dataBuffer property inside FileBuffer tests

### DIFF
--- a/Tests/RequestDLTests/Internals/Sources/Buffers/File/InternalsFileBufferTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Buffers/File/InternalsFileBufferTests.swift
@@ -487,13 +487,13 @@ class InternalsFileBufferTests: XCTestCase {
     func testFileBuffer_whenInitDataBuffer_shouldBeEqual() async throws {
         // Given
         let data = Data.randomData(length: 1_000_000)
-        let dataBuffer = Internals.FileBuffer(Internals.DataBuffer(data))
+        let fileBuffer = Internals.FileBuffer(Internals.DataBuffer(data))
 
         // When
-        let writerIndex = dataBuffer.writerIndex
-        let readerIndex = dataBuffer.readerIndex
-        let readableBytes = dataBuffer.readableBytes
-        let writableBytes = dataBuffer.writableBytes
+        let writerIndex = fileBuffer.writerIndex
+        let readerIndex = fileBuffer.readerIndex
+        let readableBytes = fileBuffer.readableBytes
+        let writableBytes = fileBuffer.writableBytes
 
         // Then
         XCTAssertEqual(writerIndex, data.count)


### PR DESCRIPTION
## Description

This PR involves renaming the dataBuffer property within the FileBuffer tests. This change was made to improve the clarity and consistency of the codebase. The modification aims to make the tests more readable and easier to understand, enhancing the overall quality and maintainability of the project.