### PR TITLE
Added getData and getBytes for immutable reading

### DIFF
--- a/Sources/RequestDL/Internals/Sources/Buffers/BufferProtocol.swift
+++ b/Sources/RequestDL/Internals/Sources/Buffers/BufferProtocol.swift
@@ -44,3 +44,17 @@ protocol BufferProtocol {
 
     mutating func moveWriterIndex(to index: Int)
 }
+
+extension BufferProtocol {
+
+    func getData() -> Data? {
+        var mutableSelf = self
+        return mutableSelf.readData(mutableSelf.readableBytes)
+    }
+
+    func getBytes() -> [UInt8]? {
+        var mutableSelf = self
+        return mutableSelf.readBytes(mutableSelf.readableBytes)
+    }
+}
+

--- a/Tests/RequestDLTests/Internals/Sources/Buffers/Data/InternalsDataBufferTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Buffers/Data/InternalsDataBufferTests.swift
@@ -505,5 +505,47 @@ class InternalsDataBufferTests: XCTestCase {
         // Then
         XCTAssertNil(data)
     }
+
+    func testDataBuffer_whenGetData() async throws {
+        // Given
+        let data = Data.randomData(length: 1_024)
+        let dataBuffer = Internals.DataBuffer(data)
+
+        // Then
+        XCTAssertEqual(dataBuffer.getData(), data)
+    }
+
+    func testDataBuffer_whenGetDataByMovingReaderIndex() async throws {
+        // Given
+        let data = Data.randomData(length: 1_024)
+        var dataBuffer = Internals.DataBuffer(data)
+
+        // When
+        dataBuffer.moveReaderIndex(to: 64)
+
+        // Then
+        XCTAssertEqual(dataBuffer.getData(), data[64 ..< data.count])
+    }
+
+    func testDataBuffer_whenGetBytes() async throws {
+        // Given
+        let data = Data.randomData(length: 1_024)
+        let dataBuffer = Internals.DataBuffer(data)
+
+        // Then
+        XCTAssertEqual(dataBuffer.getBytes(), Array(data))
+    }
+
+    func testDataBuffer_whenGetBytesByMovingReaderIndex() async throws {
+        // Given
+        let data = Data.randomData(length: 1_024)
+        var dataBuffer = Internals.DataBuffer(data)
+
+        // When
+        dataBuffer.moveReaderIndex(to: 64)
+
+        // Then
+        XCTAssertEqual(dataBuffer.getBytes(), Array(data[64 ..< data.count]))
+    }
 }
 // swiftlint:enable type_body_length file_length

--- a/Tests/RequestDLTests/Internals/Sources/Buffers/File/InternalsFileBufferTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Buffers/File/InternalsFileBufferTests.swift
@@ -512,5 +512,47 @@ class InternalsFileBufferTests: XCTestCase {
         // Then
         XCTAssertNil(data)
     }
+
+    func testFileBuffer_whenGetData() async throws {
+        // Given
+        let data = Data.randomData(length: 1_024)
+        let fileBuffer = Internals.FileBuffer(data)
+
+        // Then
+        XCTAssertEqual(fileBuffer.getData(), data)
+    }
+
+    func testFileBuffer_whenGetDataByMovingReaderIndex() async throws {
+        // Given
+        let data = Data.randomData(length: 1_024)
+        var fileBuffer = Internals.FileBuffer(data)
+
+        // When
+        fileBuffer.moveReaderIndex(to: 64)
+
+        // Then
+        XCTAssertEqual(fileBuffer.getData(), data[64 ..< data.count])
+    }
+
+    func testFileBuffer_whenGetBytes() async throws {
+        // Given
+        let data = Data.randomData(length: 1_024)
+        let fileBuffer = Internals.FileBuffer(data)
+
+        // Then
+        XCTAssertEqual(fileBuffer.getBytes(), Array(data))
+    }
+
+    func testFileBuffer_whenGetBytesByMovingReaderIndex() async throws {
+        // Given
+        let data = Data.randomData(length: 1_024)
+        var fileBuffer = Internals.FileBuffer(data)
+
+        // When
+        fileBuffer.moveReaderIndex(to: 64)
+
+        // Then
+        XCTAssertEqual(fileBuffer.getBytes(), Array(data[64 ..< data.count]))
+    }
 }
 // swiftlint:enable type_body_length file_length


### PR DESCRIPTION
## Description

This pull request includes the addition of two new methods, namely getData and getBytes, to the BufferProtocol. These methods have been introduced to enable immutable reading, which enhances the safety and efficiency of the codebase. The getData method provides an immutable view of the buffer data, while the getBytes method returns a bytes object containing a copy of the data. This change will improve the functionality and versatility of the BufferProtocol, making it easier to work with in a wide range of contexts.

This has internally effect only
