### PR TITLE
Added environment configuration inside AnyProperty

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Any/AnyProperty.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Any/AnyProperty.swift
@@ -7,7 +7,7 @@ import Foundation
 /// A type-erasing wrapper that can represent any `Property` instance.
 public struct AnyProperty: Property {
 
-    private let makeProperty: () async throws -> _PropertyOutputs
+    private let makeProperty: (_PropertyInputs) async throws -> _PropertyOutputs
 
     /// Initializes a new instance of `AnyProperty` with the given property `Content`.
     public init<Content: Property>(_ property: Content) {
@@ -16,7 +16,8 @@ public struct AnyProperty: Property {
             let root = _GraphValue.root(erased)
             let inputs = _PropertyInputs(
                 root: Erased<Content>.self,
-                body: \.self
+                body: \.self,
+                environment: $0.environment
             )
 
             return try await Erased._makeProperty(
@@ -40,7 +41,7 @@ extension AnyProperty {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         _ = inputs[self]
-        return try await property.makeProperty()
+        return try await property.makeProperty(inputs)
     }
 }
 

--- a/Tests/RequestDLTests/Properties/Sources/Extra Properties/Any/AnyPropertyTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Extra Properties/Any/AnyPropertyTests.swift
@@ -21,6 +21,28 @@ final class AnyPropertyTests: XCTestCase {
         XCTAssertEqual(request.url, "https://127.0.0.1?number=123")
     }
 
+    func testAnyProperty_whenCertificate() async throws {
+        // Given
+        let certificate = Certificates().server()
+        let path = certificate.certificateURL.absolutePath(percentEncoded: false)
+
+        // When
+        let (session, _) = try await resolve(TestProperty {
+            SecureConnection {
+                AdditionalTrusts {
+                    AnyProperty(Certificate(path))
+                }
+            }
+        })
+
+        let sut = session.configuration.secureConnection
+
+        // Then
+        XCTAssertEqual(sut?.additionalTrustRoots, [
+            .certificates([.init(path, format: .pem)])
+        ])
+    }
+
     func testNeverBody() async throws {
         // Given
         let property = AnyProperty(EmptyProperty())


### PR DESCRIPTION
# Pull Request Template

## Description

When combining `AnyProperty` with another property that uses the environment, the environment values were recreated from scratch. This caused information to be lost and possible failures depending on the implementation.

With the changes made to the `Environment` API, it was possible to identify and fix this bug. With the implementation of the test, it was possible to reproduce this scenario and verify the fix.

Fixes None

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
