### PR TITLE
Graph and Inputs refactor

### DIFF
--- a/Sources/RequestDL/Internals/Sources/Buffers/BufferProtocol.swift
+++ b/Sources/RequestDL/Internals/Sources/Buffers/BufferProtocol.swift
@@ -57,4 +57,3 @@ extension BufferProtocol {
         return mutableSelf.readBytes(mutableSelf.readableBytes)
     }
 }
-

--- a/Sources/RequestDL/Internals/Sources/Log/Message/Internals.Log.Message.swift
+++ b/Sources/RequestDL/Internals/Sources/Log/Message/Internals.Log.Message.swift
@@ -89,14 +89,6 @@ extension Internals.Log.Message {
             """
         )
     }
-
-    static func accessingAbstractContent() -> Internals.Log.Message {
-        Internals.Log.Message(
-            """
-            There was an attempt to access a variable for which access was not expected.
-            """
-        )
-    }
 }
 
 // MARK: - Resolve
@@ -222,6 +214,29 @@ extension Internals.Log.Message {
                 String(describing: type(of: object)): object,
                 String(describing: type(of: encoding)): encoding
             ] as [String: Any]
+        )
+    }
+
+    static func accessingAbstractContent() -> Internals.Log.Message {
+        Internals.Log.Message(
+            """
+            There was an attempt to access a variable for which access was not expected.
+            """
+        )
+    }
+
+    static func unexpectedGraphPathway() -> Internals.Log.Message {
+        Internals.Log.Message(
+            """
+            You are attempting to modify the graph pathway, which is not \
+            allowed. Please do not call the _makeProperty function or \
+            attempt to change the default implementation, as this can lead \
+            to errors.
+
+            If you require a different implementation, please create a new \
+            function or modify an existing one that does not affect the \
+            graph pathway.
+            """
         )
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Any/AnyProperty.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Any/AnyProperty.swift
@@ -34,7 +34,7 @@ extension AnyProperty {
         property: _GraphValue<AnyProperty>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
         return try await property.makeProperty(property, inputs)
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Any/AnyProperty.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Any/AnyProperty.swift
@@ -7,21 +7,15 @@ import Foundation
 /// A type-erasing wrapper that can represent any `Property` instance.
 public struct AnyProperty: Property {
 
-    private let makeProperty: (_PropertyInputs) async throws -> _PropertyOutputs
+    private let makeProperty: (_GraphValue<Self>, _PropertyInputs) async throws -> _PropertyOutputs
 
     /// Initializes a new instance of `AnyProperty` with the given property `Content`.
     public init<Content: Property>(_ property: Content) {
-        self.makeProperty = {
-            let erased = Erased(body: property)
-            let root = _GraphValue.root(erased)
-            let inputs = _PropertyInputs(
-                root: Erased<Content>.self,
-                body: \.self,
-                environment: $0.environment
-            )
+        self.makeProperty = { graph, inputs in
+            let id = ObjectIdentifier(Content.self)
 
-            return try await Erased._makeProperty(
-                property: root,
+            return try await Content._makeProperty(
+                property: graph.detach(id, next: property),
                 inputs: inputs
             )
         }
@@ -40,14 +34,7 @@ extension AnyProperty {
         property: _GraphValue<AnyProperty>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
-        return try await property.makeProperty(inputs)
-    }
-}
-
-extension AnyProperty {
-
-    fileprivate struct Erased<Body: Property>: Property {
-        let body: Body
+        property.assertIfNeeded()
+        return try await property.makeProperty(property, inputs)
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Async/AsyncProperty.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Async/AsyncProperty.swift
@@ -27,12 +27,6 @@ public struct AsyncProperty<Content: Property>: Property {
 
     private let content: () async throws -> Content
 
-    private var abstractContent: Content {
-        Internals.Log.failure(
-            .accessingAbstractContent()
-        )
-    }
-
     /**
      Initializes with an asynchronous content provided.
 
@@ -56,11 +50,14 @@ extension AsyncProperty {
         property: _GraphValue<AsyncProperty<Content>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        try await Content._makeProperty(
-            property: property.dynamic {
-                try await $0.content()
-            },
-            inputs: inputs[self, \.abstractContent]
+        property.assertIfNeeded()
+
+        let id = ObjectIdentifier(Content.self)
+        let content = try await property.content()
+
+        return try await Content._makeProperty(
+            property: property.detach(id, next: content),
+            inputs: inputs
         )
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Async/AsyncProperty.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Async/AsyncProperty.swift
@@ -50,7 +50,7 @@ extension AsyncProperty {
         property: _GraphValue<AsyncProperty<Content>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
 
         let id = ObjectIdentifier(Content.self)
         let content = try await property.content()

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Empty/EmptyProperty.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Empty/EmptyProperty.swift
@@ -23,7 +23,7 @@ extension EmptyProperty {
         property: _GraphValue<EmptyProperty>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
         return .init(EmptyLeaf())
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Empty/EmptyProperty.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Empty/EmptyProperty.swift
@@ -23,7 +23,7 @@ extension EmptyProperty {
         property: _GraphValue<EmptyProperty>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
+        property.assertIfNeeded()
         return .init(EmptyLeaf())
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Environment/EnvironmentProperty.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Environment/EnvironmentProperty.swift
@@ -18,7 +18,9 @@ private struct EnvironmentProperty<Content: Property, Value>: Property {
         property: _GraphValue<EnvironmentProperty<Content, Value>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        var inputs = inputs[self, \.content]
+        property.assertIfNeeded()
+
+        var inputs = inputs
         inputs.environment[keyPath: property.keyPath] = property.value
 
         return try await Content._makeProperty(

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Environment/EnvironmentProperty.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Environment/EnvironmentProperty.swift
@@ -18,7 +18,7 @@ private struct EnvironmentProperty<Content: Property, Value>: Property {
         property: _GraphValue<EnvironmentProperty<Content, Value>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
 
         var inputs = inputs
         inputs.environment[keyPath: property.keyPath] = property.value

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/ForEach/ForEach.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/ForEach/ForEach.swift
@@ -126,7 +126,7 @@ extension ForEach {
         property: _GraphValue<ForEach<Data, ID, Content>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
 
         var group = ChildrenNode()
 

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/ForEach/ForEach.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/ForEach/ForEach.swift
@@ -35,12 +35,6 @@ public struct ForEach<Data, ID, Content>: Property where Data: Sequence, ID: Has
 
     private let id: KeyPath<Data.Element, ID>
 
-    private var abstractContent: Content {
-        Internals.Log.failure(
-            .accessingAbstractContent()
-        )
-    }
-
     /**
      Creates a new instance of `ForEach`.
 
@@ -132,14 +126,17 @@ extension ForEach {
         property: _GraphValue<ForEach<Data, ID, Content>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
+        property.assertIfNeeded()
+
         var group = ChildrenNode()
 
         for element in property.data {
+            let id = element[keyPath: property.id]
+            let content = property.content(element)
+
             let output = try await Content._makeProperty(
-                property: property.dynamic {
-                    $0.content(element)
-                },
-                inputs: inputs[self, element[keyPath: property.id], \.abstractContent]
+                property: property.detach(id, next: content),
+                inputs: inputs
             )
 
             group.append(output.node)

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Group/Group.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Group/Group.swift
@@ -46,9 +46,11 @@ extension Group {
         property: _GraphValue<Group<Content>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
+        property.assertIfNeeded()
+
         let output = try await Content._makeProperty(
             property: property.content,
-            inputs: inputs[self, \.content]
+            inputs: inputs
         )
 
         var children = ChildrenNode()

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Group/Group.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Group/Group.swift
@@ -46,7 +46,7 @@ extension Group {
         property: _GraphValue<Group<Content>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
 
         let output = try await Content._makeProperty(
             property: property.content,

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Modifier/Models/PropertyModifier.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Modifier/Models/PropertyModifier.swift
@@ -15,7 +15,7 @@ public protocol PropertyModifier {
 
     typealias Content = _PropertyModifier_Content<Self>
 
-    associatedtype Body : Property
+    associatedtype Body: Property
 
     /**
      Returns a modified `Property` type based on the given `Content`.

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Modifier/Models/_PropertyModifier_Content.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Modifier/Models/_PropertyModifier_Content.swift
@@ -8,9 +8,11 @@ import Foundation
 /// to be used directly by clients of this framework.
 public struct _PropertyModifier_Content<Modifier: PropertyModifier>: Property {
 
-    private let maker: (_PropertyInputs) async throws -> _PropertyOutputs
+    typealias Inputs = (_GraphValue<Self>, _PropertyInputs)
 
-    init(_ maker: @escaping (_PropertyInputs) async throws -> _PropertyOutputs) {
+    private let maker: (Inputs) async throws -> _PropertyOutputs
+
+    init(_ maker: @escaping (Inputs) async throws -> _PropertyOutputs) {
         self.maker = maker
     }
 
@@ -24,6 +26,7 @@ public struct _PropertyModifier_Content<Modifier: PropertyModifier>: Property {
         property: _GraphValue<_PropertyModifier_Content<Modifier>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        try await property.maker(inputs)
+        property.assertIfNeeded()
+        return try await property.maker((property, inputs))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Modifier/Models/_PropertyModifier_Content.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Modifier/Models/_PropertyModifier_Content.swift
@@ -26,7 +26,7 @@ public struct _PropertyModifier_Content<Modifier: PropertyModifier>: Property {
         property: _GraphValue<_PropertyModifier_Content<Modifier>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
         return try await property.maker((property, inputs))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Modifier/ModifiedProperty.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Modifier/ModifiedProperty.swift
@@ -17,7 +17,7 @@ private struct ModifiedProperty<Content: Property, Modifier: PropertyModifier>: 
         property: _GraphValue<ModifiedProperty<Content, Modifier>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
 
         let modifiedContent = _PropertyModifier_Content<Modifier> { graph, inputs in
             let id = ObjectIdentifier(Content.self)

--- a/Sources/RequestDL/Properties/Sources/Graph/Grapth/_GraphValue.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Grapth/_GraphValue.swift
@@ -9,7 +9,7 @@ public struct _GraphValue<Content: Property> {
 
     private let id: AnyHashable
     private let content: Content
-    
+
     fileprivate let previous: _RawGraphValue?
     fileprivate var next: AnyHashable?
 
@@ -100,7 +100,7 @@ extension _GraphValue {
         previous?.assertNext(id)
     }
 
-    var hashValue: Int {
+    fileprivate func hash() -> Int {
         sequence(first: self as _RawGraphValue, next: { $0.previous })
             .map(\.next)
             .hashValue

--- a/Sources/RequestDL/Properties/Sources/Graph/Grapth/_GraphValue.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Grapth/_GraphValue.swift
@@ -96,7 +96,7 @@ private struct _GraphDetached: Hashable {
 
 extension _GraphValue {
 
-    func assertIfNeeded() {
+    func assertPathway() {
         previous?.assertNext(id)
     }
 

--- a/Sources/RequestDL/Properties/Sources/Graph/Grapth/_GraphValue.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Grapth/_GraphValue.swift
@@ -7,27 +7,102 @@ import Foundation
 @dynamicMemberLookup
 public struct _GraphValue<Content: Property> {
 
+    private let id: AnyHashable
     private let content: Content
+    
+    fileprivate let previous: _RawGraphValue?
+    fileprivate var next: AnyHashable?
 
-    private init(_ content: Content) {
+    func pointer() -> Content {
+        content
+    }
+
+    static func root(_ content: Content) -> _GraphValue<Content> {
+        .init(
+            id: ObjectIdentifier(Content.self),
+            content: content,
+            previous: nil
+        )
+    }
+
+    private init(
+        id: AnyHashable,
+        content: Content,
+        previous: _RawGraphValue?
+    ) {
+        self.id = id
         self.content = content
+        self.previous = previous
+        self.next = nil
     }
 
     subscript<Value>(dynamicMember keyPath: KeyPath<Content, Value>) -> Value {
         content[keyPath: keyPath]
     }
+}
 
-    subscript<Body: Property>(dynamicMember keyPath: KeyPath<Content, Body>) -> _GraphValue<Body> {
-        .init(content[keyPath: keyPath])
+extension _GraphValue {
+
+    subscript<Next: Property>(dynamicMember keyPath: KeyPath<Content, Next>) -> _GraphValue<Next> {
+        access(keyPath) {
+            content[keyPath: $0]
+        }
     }
 
-    func dynamic<Body: Property>(
-        _ closure: (Content) async throws -> Body
-    ) async throws -> _GraphValue<Body> {
-        try await .init(closure(content))
+    func detach<Next: Property>(_ id: AnyHashable, next: Next) -> _GraphValue<Next> {
+        access(_GraphDetached(id: id)) { _ in
+            next
+        }
     }
 
-    static func root(_ content: Content) -> Self {
-        .init(content)
+    private func access<Next: Property, ID: Hashable>(
+        _ id: ID,
+        next: (ID) -> Next
+    ) -> _GraphValue<Next> {
+        var mutableSelf = self
+        mutableSelf.next = id
+        return .init(
+            id: id,
+            content: next(id),
+            previous: mutableSelf
+        )
+    }
+}
+
+private protocol _RawGraphValue {
+
+    var previous: _RawGraphValue? { get }
+    var next: AnyHashable? { get }
+
+    func assertNext(_ id: AnyHashable)
+}
+
+extension _GraphValue: _RawGraphValue {
+
+    fileprivate func assertNext(_ id: AnyHashable) {
+        if next == id {
+            return
+        }
+
+        Internals.Log.failure(
+            .unexpectedGraphPathway()
+        )
+    }
+}
+
+private struct _GraphDetached: Hashable {
+    let id: AnyHashable
+}
+
+extension _GraphValue {
+
+    func assertIfNeeded() {
+        previous?.assertNext(id)
+    }
+
+    var hashValue: Int {
+        sequence(first: self as _RawGraphValue, next: { $0.previous })
+            .map(\.next)
+            .hashValue
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Graph/Resolve/Models/PropertyInputs.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Resolve/Models/PropertyInputs.swift
@@ -6,77 +6,11 @@ import Foundation
 
 public struct _PropertyInputs {
 
-    private let root: ObjectIdentifier
-    private let id: AnyHashable
-    private let body: ObjectIdentifier
     var environment: EnvironmentValues
 
-    init<Root: Property, ID: Hashable, Body: Property>(
-        root: Root.Type,
-        id: ID,
-        body: KeyPath<Root, Body>,
-        environment: EnvironmentValues = .init()
+    init(
+        environment: EnvironmentValues
     ) {
-        self.root = ObjectIdentifier(root)
-        self.id = id
-        self.body = ObjectIdentifier(Body.self)
         self.environment = environment
-    }
-
-    subscript<Root: Property, ID: Hashable, Body: Property>(
-        root: Root.Type,
-        id: ID,
-        body: KeyPath<Root, Body>
-    ) -> _PropertyInputs {
-        precondition(self.body == ObjectIdentifier(root))
-
-        var inputs = _PropertyInputs(
-            root: root,
-            id: id,
-            body: body
-        )
-        inputs.environment = environment
-        return inputs
-    }
-}
-
-extension _PropertyInputs {
-
-    init<Root: Property, Body: Property>(
-        root: Root.Type,
-        body: KeyPath<Root, Body>,
-        environment: EnvironmentValues = .init()
-    ) {
-        self.init(
-            root: root,
-            id: ObjectIdentifier(Body.self),
-            body: body,
-            environment: environment
-        )
-    }
-
-    init<Root: Property>(
-        root: Root.Type,
-        environment: EnvironmentValues = .init()
-    ) {
-        self.init(
-            root: root,
-            body: \.body,
-            environment: environment
-        )
-    }
-}
-
-extension _PropertyInputs {
-
-    subscript<Root: Property, Body: Property>(
-        root: Root.Type,
-        body: KeyPath<Root, Body>
-    ) -> _PropertyInputs {
-        self[root, ObjectIdentifier(Body.self), body]
-    }
-
-    subscript<Root: Property>(_ root: Root.Type) -> _PropertyInputs {
-        self[root, \.body]
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Graph/Resolve/Resolve.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Resolve/Resolve.swift
@@ -13,7 +13,9 @@ struct Resolve<Root: Property> {
     }
 
     private func inputs() -> _PropertyInputs {
-        .init(root: _Root.self, body: \.self)
+        .init(
+            environment: .init()
+        )
     }
 
     private func outputs() async throws -> _PropertyOutputs {

--- a/Sources/RequestDL/Properties/Sources/Headers/Authorization/Authorization.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Authorization/Authorization.swift
@@ -59,7 +59,7 @@ extension Authorization {
         property: _GraphValue<Authorization>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
+        property.assertIfNeeded()
         return .init(Leaf(Node(
             type: property.type,
             token: property.token

--- a/Sources/RequestDL/Properties/Sources/Headers/Authorization/Authorization.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Authorization/Authorization.swift
@@ -59,7 +59,7 @@ extension Authorization {
         property: _GraphValue<Authorization>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
         return .init(Leaf(Node(
             type: property.type,
             token: property.token

--- a/Sources/RequestDL/Properties/Sources/Headers/Header Group/HeaderGroup.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Header Group/HeaderGroup.swift
@@ -72,7 +72,7 @@ extension HeaderGroup {
         property: _GraphValue<HeaderGroup<Content>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
 
         let outputs = try await Content._makeProperty(
             property: property.content,

--- a/Sources/RequestDL/Properties/Sources/Headers/Header Group/HeaderGroup.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Header Group/HeaderGroup.swift
@@ -72,7 +72,7 @@ extension HeaderGroup {
         property: _GraphValue<HeaderGroup<Content>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        let inputs = inputs[self, \.content]
+        property.assertIfNeeded()
 
         let outputs = try await Content._makeProperty(
             property: property.content,

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept/Headers.Accept.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept/Headers.Accept.swift
@@ -36,7 +36,7 @@ extension Headers.Accept {
         property: _GraphValue<Headers.Accept>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
+        property.assertIfNeeded()
         return .init(Leaf(Headers.Node(
             property.type.rawValue,
             forKey: "Accept"

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept/Headers.Accept.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept/Headers.Accept.swift
@@ -36,7 +36,7 @@ extension Headers.Accept {
         property: _GraphValue<Headers.Accept>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
         return .init(Leaf(Headers.Node(
             property.type.rawValue,
             forKey: "Accept"

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Any/Headers.Any.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Any/Headers.Any.swift
@@ -38,7 +38,7 @@ extension Headers.`Any` {
         property: _GraphValue<Headers.`Any`>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
+        property.assertIfNeeded()
         return .init(Leaf(Headers.Node(
             property.value,
             forKey: property.key

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Any/Headers.Any.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Any/Headers.Any.swift
@@ -38,7 +38,7 @@ extension Headers.`Any` {
         property: _GraphValue<Headers.`Any`>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
         return .init(Leaf(Headers.Node(
             property.value,
             forKey: property.key

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Cache/Headers.Cache.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Cache/Headers.Cache.swift
@@ -65,7 +65,7 @@ extension Headers.Cache {
         property: _GraphValue<Headers.Cache>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
 
         return .init(Leaf(Headers.Node(
             property.contents.joined(separator: ", "),

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Cache/Headers.Cache.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Cache/Headers.Cache.swift
@@ -65,7 +65,8 @@ extension Headers.Cache {
         property: _GraphValue<Headers.Cache>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
+        property.assertIfNeeded()
+
         return .init(Leaf(Headers.Node(
             property.contents.joined(separator: ", "),
             forKey: "Cache-Control"

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Content Length/Headers.ContentLength.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Content Length/Headers.ContentLength.swift
@@ -34,7 +34,7 @@ extension Headers.ContentLength {
         property: _GraphValue<Headers.ContentLength>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
+        property.assertIfNeeded()
         return .init(Leaf(Headers.Node(
             property.bytes,
             forKey: "Content-Length"

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Content Length/Headers.ContentLength.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Content Length/Headers.ContentLength.swift
@@ -34,7 +34,7 @@ extension Headers.ContentLength {
         property: _GraphValue<Headers.ContentLength>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
         return .init(Leaf(Headers.Node(
             property.bytes,
             forKey: "Content-Length"

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Content Type/Headers.ContentType.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Content Type/Headers.ContentType.swift
@@ -34,7 +34,7 @@ extension Headers.ContentType {
         property: _GraphValue<Headers.ContentType>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
         return .init(Leaf(
             Headers.Node(
                 property.contentType.rawValue,

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Content Type/Headers.ContentType.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Content Type/Headers.ContentType.swift
@@ -34,7 +34,7 @@ extension Headers.ContentType {
         property: _GraphValue<Headers.ContentType>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
+        property.assertIfNeeded()
         return .init(Leaf(
             Headers.Node(
                 property.contentType.rawValue,

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Host/Headers.Host.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Host/Headers.Host.swift
@@ -49,7 +49,7 @@ extension Headers.Host {
         property: _GraphValue<Headers.Host>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
+        property.assertIfNeeded()
         return .init(Leaf(Headers.Node(
             property.value,
             forKey: "Host"

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Host/Headers.Host.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Host/Headers.Host.swift
@@ -49,7 +49,7 @@ extension Headers.Host {
         property: _GraphValue<Headers.Host>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
         return .init(Leaf(Headers.Node(
             property.value,
             forKey: "Host"

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Origin/Headers.Origin.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Origin/Headers.Origin.swift
@@ -61,7 +61,7 @@ extension Headers.Origin {
         property: _GraphValue<Headers.Origin>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
+        property.assertIfNeeded()
         return .init(Leaf(Headers.Node(
             property.value,
             forKey: "Origin"

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Origin/Headers.Origin.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Origin/Headers.Origin.swift
@@ -61,7 +61,7 @@ extension Headers.Origin {
         property: _GraphValue<Headers.Origin>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
         return .init(Leaf(Headers.Node(
             property.value,
             forKey: "Origin"

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Referer/Headers.Referer.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Referer/Headers.Referer.swift
@@ -43,7 +43,7 @@ extension Headers.Referer {
         property: _GraphValue<Headers.Referer>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
+        property.assertIfNeeded()
         return .init(Leaf(Headers.Node(
             property.value,
             forKey: "Referer"

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Referer/Headers.Referer.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Referer/Headers.Referer.swift
@@ -43,7 +43,7 @@ extension Headers.Referer {
         property: _GraphValue<Headers.Referer>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
         return .init(Leaf(Headers.Node(
             property.value,
             forKey: "Referer"

--- a/Sources/RequestDL/Properties/Sources/Headers/Method/RequestMethod.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Method/RequestMethod.swift
@@ -60,7 +60,7 @@ extension RequestMethod {
         property: _GraphValue<RequestMethod>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
+        property.assertIfNeeded()
         return .init(Leaf(Node(
             httpMethod: property.httpMethod.rawValue
         )))

--- a/Sources/RequestDL/Properties/Sources/Headers/Method/RequestMethod.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Method/RequestMethod.swift
@@ -60,7 +60,7 @@ extension RequestMethod {
         property: _GraphValue<RequestMethod>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
         return .init(Leaf(Node(
             httpMethod: property.httpMethod.rawValue
         )))

--- a/Sources/RequestDL/Properties/Sources/Headers/Reading Mode/ReadingMode.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Reading Mode/ReadingMode.swift
@@ -57,7 +57,7 @@ extension ReadingMode {
         property: _GraphValue<ReadingMode>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
+        property.assertIfNeeded()
         return .init(Leaf(Node(mode: property.mode)))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Reading Mode/ReadingMode.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Reading Mode/ReadingMode.swift
@@ -57,7 +57,7 @@ extension ReadingMode {
         property: _GraphValue<ReadingMode>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
         return .init(Leaf(Node(mode: property.mode)))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Session/Session.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Session/Session.swift
@@ -194,7 +194,7 @@ extension Session {
         property: _GraphValue<Session>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
         return .init(Leaf(Node(
             configuration: property.configuration,
             provider: property.provider

--- a/Sources/RequestDL/Properties/Sources/Headers/Session/Session.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Session/Session.swift
@@ -194,7 +194,7 @@ extension Session {
         property: _GraphValue<Session>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
+        property.assertIfNeeded()
         return .init(Leaf(Node(
             configuration: property.configuration,
             provider: property.provider

--- a/Sources/RequestDL/Properties/Sources/Headers/Timeout/Timeout.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Timeout/Timeout.swift
@@ -80,7 +80,7 @@ extension Timeout {
         property: _GraphValue<Timeout>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
+        property.assertIfNeeded()
         return .init(Leaf(Node(
             timeout: property.timeout,
             source: property.source

--- a/Sources/RequestDL/Properties/Sources/Headers/Timeout/Timeout.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Timeout/Timeout.swift
@@ -80,7 +80,7 @@ extension Timeout {
         property: _GraphValue<Timeout>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
         return .init(Leaf(Node(
             timeout: property.timeout,
             source: property.source

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form Data/FormData.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form Data/FormData.swift
@@ -69,7 +69,7 @@ extension FormData {
         property: _GraphValue<FormData>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
+        property.assertIfNeeded()
         return .init(Leaf(FormNode {
             PartFormRawValue(property.buffer.getData() ?? Data(), forHeaders: [
                 kContentDisposition: kContentDispositionValue(

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form Data/FormData.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form Data/FormData.swift
@@ -69,7 +69,7 @@ extension FormData {
         property: _GraphValue<FormData>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
         return .init(Leaf(FormNode {
             PartFormRawValue(property.buffer.getData() ?? Data(), forHeaders: [
                 kContentDisposition: kContentDispositionValue(

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form File/FormFile.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form File/FormFile.swift
@@ -73,7 +73,7 @@ extension FormFile {
         property: _GraphValue<FormFile>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
 
         return .init(Leaf(FormNode {
             let data = (try? Data(contentsOf: property.url)) ?? Data()

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form File/FormFile.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form File/FormFile.swift
@@ -73,7 +73,8 @@ extension FormFile {
         property: _GraphValue<FormFile>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
+        property.assertIfNeeded()
+
         return .init(Leaf(FormNode {
             let data = (try? Data(contentsOf: property.url)) ?? Data()
             return PartFormRawValue(data, forHeaders: [

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form Group/FormGroup.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form Group/FormGroup.swift
@@ -67,7 +67,7 @@ extension FormGroup {
         property: _GraphValue<FormGroup<Content>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        let inputs = inputs[self, \.content]
+        property.assertIfNeeded()
 
         let outputs = try await Content._makeProperty(
             property: property.content,

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form Group/FormGroup.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form Group/FormGroup.swift
@@ -67,7 +67,7 @@ extension FormGroup {
         property: _GraphValue<FormGroup<Content>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
 
         let outputs = try await Content._makeProperty(
             property: property.content,

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form Value/FormValue.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form Value/FormValue.swift
@@ -43,7 +43,7 @@ extension FormValue {
         property: _GraphValue<FormValue>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
+        property.assertIfNeeded()
         return .init(Leaf(FormNode {
             PartFormRawValue(Data("\(property.value)".utf8), forHeaders: [
                 kContentDisposition: kContentDispositionValue(

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form Value/FormValue.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form Value/FormValue.swift
@@ -43,7 +43,7 @@ extension FormValue {
         property: _GraphValue<FormValue>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
         return .init(Leaf(FormNode {
             PartFormRawValue(Data("\(property.value)".utf8), forHeaders: [
                 kContentDisposition: kContentDispositionValue(

--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload/Payload.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload/Payload.swift
@@ -136,7 +136,7 @@ extension Payload {
         property: _GraphValue<Payload<Provider>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
+        property.assertIfNeeded()
         return .init(Leaf(Node {
             property.source(property.provider)
         }))

--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload/Payload.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload/Payload.swift
@@ -136,7 +136,7 @@ extension Payload {
         property: _GraphValue<Payload<Provider>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
         return .init(Leaf(Node {
             property.source(property.provider)
         }))

--- a/Sources/RequestDL/Properties/Sources/Property.swift
+++ b/Sources/RequestDL/Properties/Sources/Property.swift
@@ -56,7 +56,7 @@ extension Property {
         property: _GraphValue<Self>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
 
         return try await Body._makeProperty(
             property: property.body,

--- a/Sources/RequestDL/Properties/Sources/Property.swift
+++ b/Sources/RequestDL/Properties/Sources/Property.swift
@@ -56,9 +56,11 @@ extension Property {
         property: _GraphValue<Self>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        try await Body._makeProperty(
+        property.assertIfNeeded()
+
+        return try await Body._makeProperty(
             property: property.body,
-            inputs: inputs[self]
+            inputs: inputs
         )
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Result Builder/Either/_EitherContent.swift
+++ b/Sources/RequestDL/Properties/Sources/Result Builder/Either/_EitherContent.swift
@@ -57,16 +57,18 @@ extension _EitherContent {
         property: _GraphValue<_EitherContent<First, Second>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
+        property.assertIfNeeded()
+
         switch property.source {
         case .first:
             return try await First._makeProperty(
                 property: property.first,
-                inputs: inputs[self, \.first]
+                inputs: inputs
             )
         case .second:
             return try await Second._makeProperty(
                 property: property.second,
-                inputs: inputs[self, \.second]
+                inputs: inputs
             )
         }
     }

--- a/Sources/RequestDL/Properties/Sources/Result Builder/Either/_EitherContent.swift
+++ b/Sources/RequestDL/Properties/Sources/Result Builder/Either/_EitherContent.swift
@@ -57,7 +57,7 @@ extension _EitherContent {
         property: _GraphValue<_EitherContent<First, Second>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
 
         switch property.source {
         case .first:

--- a/Sources/RequestDL/Properties/Sources/Result Builder/Optional/_OptionalContent.swift
+++ b/Sources/RequestDL/Properties/Sources/Result Builder/Optional/_OptionalContent.swift
@@ -31,7 +31,7 @@ extension _OptionalContent {
         property: _GraphValue<_OptionalContent<Content>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
 
         switch property.source {
         case .none:

--- a/Sources/RequestDL/Properties/Sources/Result Builder/Optional/_OptionalContent.swift
+++ b/Sources/RequestDL/Properties/Sources/Result Builder/Optional/_OptionalContent.swift
@@ -31,13 +31,15 @@ extension _OptionalContent {
         property: _GraphValue<_OptionalContent<Content>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
+        property.assertIfNeeded()
+
         switch property.source {
         case .none:
             return .init(EmptyLeaf())
         case .some:
             return try await Content._makeProperty(
                 property: property.content,
-                inputs: inputs[self, \.content]
+                inputs: inputs
             )
         }
     }

--- a/Sources/RequestDL/Properties/Sources/Result Builder/Partial/_PartialContent.swift
+++ b/Sources/RequestDL/Properties/Sources/Result Builder/Partial/_PartialContent.swift
@@ -24,7 +24,7 @@ extension _PartialContent {
         property: _GraphValue<_PartialContent<Accumulated, Next>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
 
         let accumulatedOutput = try await Accumulated._makeProperty(
             property: property.accumulated,

--- a/Sources/RequestDL/Properties/Sources/Result Builder/Partial/_PartialContent.swift
+++ b/Sources/RequestDL/Properties/Sources/Result Builder/Partial/_PartialContent.swift
@@ -24,14 +24,16 @@ extension _PartialContent {
         property: _GraphValue<_PartialContent<Accumulated, Next>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
+        property.assertIfNeeded()
+
         let accumulatedOutput = try await Accumulated._makeProperty(
             property: property.accumulated,
-            inputs: inputs[self, \.accumulated]
+            inputs: inputs
         )
 
         let nextOutput = try await Next._makeProperty(
             property: property.next,
-            inputs: inputs[self, \.next]
+            inputs: inputs
         )
 
         var children = ChildrenNode()

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Additional Trusts/AdditionalTrusts.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Additional Trusts/AdditionalTrusts.swift
@@ -128,7 +128,7 @@ extension AdditionalTrusts {
         property: _GraphValue<AdditionalTrusts<Content>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
 
         switch property.source {
         case .file(let file):

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Additional Trusts/AdditionalTrusts.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Additional Trusts/AdditionalTrusts.swift
@@ -128,22 +128,19 @@ extension AdditionalTrusts {
         property: _GraphValue<AdditionalTrusts<Content>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
+        property.assertIfNeeded()
+
         switch property.source {
         case .file(let file):
-            _ = inputs[self]
-
             return .init(Leaf(SecureConnectionNode(
                 Node(source: .file(file))
             )))
         case .bytes(let bytes):
-            _ = inputs[self]
-
             return .init(Leaf(SecureConnectionNode(
                 Node(source: .bytes(bytes))
             )))
         case .content:
-            var inputs = inputs[self, \.content]
-
+            var inputs = inputs
             inputs.environment.certificateProperty = .additionalTrust
 
             let outputs = try await Content._makeProperty(

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Certificate/Certificate.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Certificate/Certificate.swift
@@ -72,7 +72,7 @@ extension Certificate {
         property: _GraphValue<Certificate>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
 
         guard let certificateProperty = inputs.environment.certificateProperty else {
             Internals.Log.failure(

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Certificate/Certificate.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Certificate/Certificate.swift
@@ -72,7 +72,7 @@ extension Certificate {
         property: _GraphValue<Certificate>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        let inputs = inputs[self]
+        property.assertIfNeeded()
 
         guard let certificateProperty = inputs.environment.certificateProperty else {
             Internals.Log.failure(

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Certificates/Certificates.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Certificates/Certificates.swift
@@ -126,22 +126,19 @@ extension Certificates {
         property: _GraphValue<Certificates<Content>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
+        property.assertIfNeeded()
+
         switch property.source {
         case .file(let file):
-            _ = inputs[self]
-
             return .init(Leaf(SecureConnectionNode(
                 Node(source: .file(file))
             )))
         case .bytes(let bytes):
-            _ = inputs[self]
-
             return .init(Leaf(SecureConnectionNode(
                 Node(source: .bytes(bytes))
             )))
         case .content:
-            var inputs = inputs[self, \.content]
-
+            var inputs = inputs
             inputs.environment.certificateProperty = .chain
 
             let outputs = try await Content._makeProperty(

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Certificates/Certificates.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Certificates/Certificates.swift
@@ -126,7 +126,7 @@ extension Certificates {
         property: _GraphValue<Certificates<Content>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
 
         switch property.source {
         case .file(let file):

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/PSK/PSKIdentity.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/PSK/PSKIdentity.swift
@@ -105,7 +105,7 @@ extension PSKIdentity {
         property: _GraphValue<PSKIdentity<PSK>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
+        property.assertIfNeeded()
         return .init(Leaf(SecureConnectionNode(
             Node(
                 source: property.source,

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/PSK/PSKIdentity.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/PSK/PSKIdentity.swift
@@ -105,7 +105,7 @@ extension PSKIdentity {
         property: _GraphValue<PSKIdentity<PSK>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
         return .init(Leaf(SecureConnectionNode(
             Node(
                 source: property.source,

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Private Key/PrivateKey.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Private Key/PrivateKey.swift
@@ -150,7 +150,7 @@ extension PrivateKey {
         property: _GraphValue<PrivateKey<Password>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
+        property.assertIfNeeded()
         return .init(Leaf(SecureConnectionNode(
             Node(source: property.source)
         )))

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Private Key/PrivateKey.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Private Key/PrivateKey.swift
@@ -150,7 +150,7 @@ extension PrivateKey {
         property: _GraphValue<PrivateKey<Password>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
         return .init(Leaf(SecureConnectionNode(
             Node(source: property.source)
         )))

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/SecureConnection.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/SecureConnection.swift
@@ -232,7 +232,7 @@ extension SecureConnection {
         property: _GraphValue<SecureConnection<Content>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
 
         let outputs = try await Content._makeProperty(
             property: property.content,

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/SecureConnection.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/SecureConnection.swift
@@ -232,7 +232,7 @@ extension SecureConnection {
         property: _GraphValue<SecureConnection<Content>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        let inputs = inputs[self, \.content]
+        property.assertIfNeeded()
 
         let outputs = try await Content._makeProperty(
             property: property.content,

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Trusts/DefaultTrusts.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Trusts/DefaultTrusts.swift
@@ -34,7 +34,7 @@ extension DefaultTrusts {
         property: _GraphValue<DefaultTrusts>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
         return .init(Leaf(SecureConnectionNode(Node())))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Trusts/DefaultTrusts.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Trusts/DefaultTrusts.swift
@@ -34,7 +34,7 @@ extension DefaultTrusts {
         property: _GraphValue<DefaultTrusts>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
+        property.assertIfNeeded()
         return .init(Leaf(SecureConnectionNode(Node())))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Trusts/Trusts.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Trusts/Trusts.swift
@@ -124,22 +124,19 @@ extension Trusts {
         property: _GraphValue<Trusts<Content>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
+        property.assertIfNeeded()
+
         switch property.source {
         case .file(let file):
-            _ = inputs[self]
-
             return .init(Leaf(SecureConnectionNode(
                 Node(source: .file(file))
             )))
         case .bytes(let bytes):
-            _ = inputs[self]
-
             return .init(Leaf(SecureConnectionNode(
                 Node(source: .bytes(bytes))
             )))
         case .content:
-            var inputs = inputs[self, \.content]
-
+            var inputs = inputs
             inputs.environment.certificateProperty = .trust
 
             let outputs = try await Content._makeProperty(

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Trusts/Trusts.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Trusts/Trusts.swift
@@ -124,7 +124,7 @@ extension Trusts {
         property: _GraphValue<Trusts<Content>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
 
         switch property.source {
         case .file(let file):

--- a/Sources/RequestDL/Properties/Sources/URL/Path/Path.swift
+++ b/Sources/RequestDL/Properties/Sources/URL/Path/Path.swift
@@ -93,7 +93,7 @@ extension Path {
         property: _GraphValue<Path>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
 
         let path = property.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
 

--- a/Sources/RequestDL/Properties/Sources/URL/Path/Path.swift
+++ b/Sources/RequestDL/Properties/Sources/URL/Path/Path.swift
@@ -93,7 +93,7 @@ extension Path {
         property: _GraphValue<Path>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
+        property.assertIfNeeded()
 
         let path = property.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
 

--- a/Sources/RequestDL/Properties/Sources/URL/Query Group/QueryGroup.swift
+++ b/Sources/RequestDL/Properties/Sources/URL/Query Group/QueryGroup.swift
@@ -71,7 +71,7 @@ extension QueryGroup {
         property: _GraphValue<QueryGroup<Content>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        let inputs = inputs[self, \.content]
+        property.assertIfNeeded()
 
         let output = try await Content._makeProperty(
             property: property.content,

--- a/Sources/RequestDL/Properties/Sources/URL/Query Group/QueryGroup.swift
+++ b/Sources/RequestDL/Properties/Sources/URL/Query Group/QueryGroup.swift
@@ -71,7 +71,7 @@ extension QueryGroup {
         property: _GraphValue<QueryGroup<Content>>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
 
         let output = try await Content._makeProperty(
             property: property.content,

--- a/Sources/RequestDL/Properties/Sources/URL/Query/Query.swift
+++ b/Sources/RequestDL/Properties/Sources/URL/Query/Query.swift
@@ -68,7 +68,7 @@ extension Query {
         property: _GraphValue<Query>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
         return .init(Leaf(Node(
             key: property.key,
             value: "\(property.value)"

--- a/Sources/RequestDL/Properties/Sources/URL/Query/Query.swift
+++ b/Sources/RequestDL/Properties/Sources/URL/Query/Query.swift
@@ -68,7 +68,7 @@ extension Query {
         property: _GraphValue<Query>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
+        property.assertIfNeeded()
         return .init(Leaf(Node(
             key: property.key,
             value: "\(property.value)"

--- a/Sources/RequestDL/Properties/Sources/URL/URL/BaseURL.swift
+++ b/Sources/RequestDL/Properties/Sources/URL/URL/BaseURL.swift
@@ -131,7 +131,7 @@ extension BaseURL {
         property: _GraphValue<BaseURL>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        property.assertIfNeeded()
+        property.assertPathway()
 
         guard let baseURL = URL(string: property.absoluteString) else {
             Internals.Log.failure(

--- a/Sources/RequestDL/Properties/Sources/URL/URL/BaseURL.swift
+++ b/Sources/RequestDL/Properties/Sources/URL/URL/BaseURL.swift
@@ -131,7 +131,7 @@ extension BaseURL {
         property: _GraphValue<BaseURL>,
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
-        _ = inputs[self]
+        property.assertIfNeeded()
 
         guard let baseURL = URL(string: property.absoluteString) else {
             Internals.Log.failure(

--- a/Tests/RequestDLTests/Properties/Sources/Extra Properties/Environment/EnvironmentTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Extra Properties/Environment/EnvironmentTests.swift
@@ -23,7 +23,7 @@ class EnvironmentTests: XCTestCase {
             property: _GraphValue<EnvironmentTests.IntegerReceiver>,
             inputs: _PropertyInputs
         ) async throws -> _PropertyOutputs {
-            property.assertIfNeeded()
+            property.assertPathway()
             property.value(inputs.environment.integer)
             return .init(EmptyLeaf())
         }

--- a/Tests/RequestDLTests/Properties/Sources/Extra Properties/Environment/EnvironmentTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Extra Properties/Environment/EnvironmentTests.swift
@@ -23,7 +23,7 @@ class EnvironmentTests: XCTestCase {
             property: _GraphValue<EnvironmentTests.IntegerReceiver>,
             inputs: _PropertyInputs
         ) async throws -> _PropertyOutputs {
-            let inputs = inputs[self]
+            property.assertIfNeeded()
             property.value(inputs.environment.integer)
             return .init(EmptyLeaf())
         }


### PR DESCRIPTION
## Description

We refactored `_GraphValue` to concentrate all operations and state verification of the property graph. To do this, we used the current implementation of `_PropertyInputs` as a basis.

After the refactoring, `_PropertyInputs` only contains input values that can be consumed during the construction of properties. An example of this is the current use of the environment to obtain environment values.

This change only has an internal effect and will enable the development of new features for RequestDL.

Fixes None

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
