### PR TITLE
Added @Environment propertyWrapper

### DIFF
--- a/Sources/RequestDL/Internals/Sources/Log/Message/Internals.Log.Message.swift
+++ b/Sources/RequestDL/Internals/Sources/Log/Message/Internals.Log.Message.swift
@@ -239,6 +239,23 @@ extension Internals.Log.Message {
             """
         )
     }
+
+    static func environmentNilValue<KeyPath>(_ keyPath: KeyPath) -> Internals.Log.Message {
+        Internals.Log.Message(
+            """
+            This can occur if the property wrapper's key path does not \
+            exist in the current environment, or if the environment has \
+            not been properly set up.
+
+            Please ensure that the environment is correctly configured \
+            and that the key path provided to the property wrapper is \
+            valid.
+            """,
+            parameters: [
+                String(describing: type(of: keyPath)): keyPath
+            ]
+        )
+    }
 }
 
 // MARK: - BaseURL

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Environment/Models/Environment.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Environment/Models/Environment.swift
@@ -1,0 +1,100 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+/**
+ A property wrapper that provides access to values stored in the `EnvironmentValues`
+ object.
+
+ The `Environment` property wrapper is used to access values that are stored in the
+ `EnvironmentValues` object. This object contains values that are shared across the
+ request tasks and can be accessed by any property within the request's hierarchy. By
+ using the `Environment` property wrapper, you can access these values in a type-safe
+ manner and with less boilerplate code.
+
+ **Usage**
+
+ To use the `Environment` property wrapper, create a new instance of it and pass in a
+ key path that  points to the value you want to access in the `EnvironmentValues`
+ object. For example, to access the `contentType` value, you can create an instance of
+ `Environment` with the `\.contentType` key path:
+
+ ```swift
+ @Environment(\.contentType) var contentType: ContentType
+ ```
+
+ This will create a new property named `contentType` that you can use to access the
+ `contentType` value anywhere in your property code.
+
+ **Example**
+
+ The following example shows how to use the `wrappedValue` property to access the
+ `contentType` value in a `Property`:
+
+ ```swift
+ struct DefaultHeader: Property {
+     @Environment(\.contentType) var contentType: ContentType
+
+     var body: some Property {
+         Headers.ContentType(contentType)
+     }
+ }
+ ```
+ */
+@propertyWrapper
+public struct Environment<Value>: PropertyValue {
+
+    @PropertyContainer private var value: Value?
+
+    private let keyPath: KeyPath<EnvironmentValues, Value>
+
+    /**
+     Initializes a new instance of the `Environment` property wrapper.
+
+     - Parameter keyPath: The key path that points to the value in the `EnvironmentValues` object.
+     */
+    public init(_ keyPath: KeyPath<EnvironmentValues, Value>) {
+        self.keyPath = keyPath
+    }
+
+    /**
+     The wrapped value that provides access to the value stored in the `EnvironmentValues` object.
+
+     To access the value stored in the `EnvironmentValues` object, use the `wrappedValue`
+     property on the `Environment` property wrapper. This property returns the value that is stored
+     in the `EnvironmentValues` object for the key path provided to the initializer.
+
+     ## Example
+
+     The following example shows how to use the `wrappedValue` property to access the
+     `contentType` value in a `Property`:
+
+     ```swift
+         struct DefaultHeader: Property {
+             @Environment(\.contentType) var contentType: ContentType
+
+             var body: some Property {
+                 Headers.ContentType(contentType)
+             }
+         }
+     ```
+     */
+    public var wrappedValue: Value {
+        guard let value else {
+            Internals.Log.failure(
+                .environmentNilValue(keyPath)
+            )
+        }
+
+        return value
+    }
+}
+
+extension Environment: EnvironmentPropertyValue {
+
+    func setValue(for values: EnvironmentValues) {
+        value = values[keyPath: keyPath]
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Environment/Models/EnvironmentPropertyValue.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Environment/Models/EnvironmentPropertyValue.swift
@@ -1,0 +1,10 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+protocol EnvironmentPropertyValue: PropertyValue {
+
+    func setValue(for values: EnvironmentValues)
+}

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Environment/Models/PropertyEnvironmentUpdater.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Environment/Models/PropertyEnvironmentUpdater.swift
@@ -1,0 +1,24 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+struct PropertyEnvironmentUpdater<Content> {
+
+    private let content: Content
+
+    init(_ content: Content) {
+        self.content = content
+    }
+
+    func callAsFunction(_ values: EnvironmentValues) {
+        let mirror = PropertyMirror(content)
+
+        for propertyValue in mirror() {
+            if let environment = propertyValue as? EnvironmentPropertyValue {
+                environment.setValue(for: values)
+            }
+        }
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Modifier/ModifiedProperty.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Modifier/ModifiedProperty.swift
@@ -28,6 +28,13 @@ private struct ModifiedProperty<Content: Property, Modifier: PropertyModifier>: 
             )
         }
 
+        let updater = GraphValueUpdater(
+            hashValue: property.pathwayHashValue,
+            content: property.modifier
+        )
+
+        updater(inputs)
+
         let id = ObjectIdentifier(Modifier.Body.self)
         let content = property.modifier.body(content: modifiedContent)
 

--- a/Sources/RequestDL/Properties/Sources/Graph/Grapth/_GraphValue.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Grapth/_GraphValue.swift
@@ -100,7 +100,7 @@ extension _GraphValue {
         previous?.assertNext(id)
     }
 
-    fileprivate func hash() -> Int {
+    var pathwayHashValue: Int {
         sequence(first: self as _RawGraphValue, next: { $0.previous })
             .map(\.next)
             .hashValue

--- a/Sources/RequestDL/Properties/Sources/Property.swift
+++ b/Sources/RequestDL/Properties/Sources/Property.swift
@@ -58,6 +58,9 @@ extension Property {
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
 
+        let updater = GraphValueUpdater(property)
+        updater(inputs)
+
         return try await Body._makeProperty(
             property: property.body,
             inputs: inputs

--- a/Sources/RequestDL/Properties/Sources/Value/Property Container/PropertyContainer.swift
+++ b/Sources/RequestDL/Properties/Sources/Value/Property Container/PropertyContainer.swift
@@ -1,0 +1,55 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+@propertyWrapper
+struct PropertyContainer<Value>: PropertyValue {
+
+    private let stored: Stored
+
+    init(wrappedValue: Value) {
+        self.stored = .init(wrappedValue)
+    }
+
+    init() where Value: ExpressibleByNilLiteral {
+        self.stored = .init(.init(nilLiteral: ()))
+    }
+
+    var wrappedValue: Value {
+        get { stored.value }
+        nonmutating
+        set { stored.value = newValue }
+    }
+}
+
+extension PropertyContainer {
+
+    fileprivate class Stored {
+        var value: Value
+
+        init(_ value: Value) {
+            self.value = value
+        }
+    }
+}
+
+extension PropertyValue {
+
+    func container<Value>(
+        _ valueType: Value.Type = Value.self
+    ) -> PropertyContainer<Value>? {
+        if let box = self as? PropertyContainer<Value> {
+            return box
+        }
+
+        for child in Mirror(reflecting: self).children {
+            if let property = child.value as? PropertyValue {
+                return property.container(valueType)
+            }
+        }
+
+        return nil
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Value/Property Value/Model/GraphValueUpdater.swift
+++ b/Sources/RequestDL/Properties/Sources/Value/Property Value/Model/GraphValueUpdater.swift
@@ -1,0 +1,29 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+struct GraphValueUpdater<Content> {
+
+    private let hashValue: Int
+    private let content: Content
+
+    init(_ property: _GraphValue<Content>) where Content: Property {
+        self.hashValue = property.pathwayHashValue
+        self.content = property.pointer()
+    }
+
+    init(
+        hashValue: Int,
+        content: Content
+    ) {
+        self.hashValue = hashValue
+        self.content = content
+    }
+
+    func callAsFunction(_ inputs: _PropertyInputs) {
+        let environmentUpdater = PropertyEnvironmentUpdater(content)
+        environmentUpdater(inputs.environment)
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Value/Property Value/Model/PropertyMirror.swift
+++ b/Sources/RequestDL/Properties/Sources/Value/Property Value/Model/PropertyMirror.swift
@@ -1,0 +1,20 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+struct PropertyMirror<Content> {
+
+    private let content: Content
+
+    init(_ content: Content) {
+        self.content = content
+    }
+
+    func callAsFunction() -> [PropertyValue] {
+        Mirror(reflecting: content).children.compactMap {
+            $0.value as? PropertyValue
+        }
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Value/Property Value/PropertyValue.swift
+++ b/Sources/RequestDL/Properties/Sources/Value/Property Value/PropertyValue.swift
@@ -1,0 +1,8 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+public protocol PropertyValue {}
+

--- a/Tests/RequestDLTests/Properties/Sources/Extra Properties/Environment/EnvironmentTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Extra Properties/Environment/EnvironmentTests.swift
@@ -3,7 +3,7 @@
 */
 
 import XCTest
-@testable @_spi(Private) import RequestDL
+@testable import RequestDL
 
 class EnvironmentTests: XCTestCase {
 
@@ -13,19 +13,12 @@ class EnvironmentTests: XCTestCase {
 
     struct IntegerReceiver: Property {
 
+        @Environment(\.integer) var integer
         let value: (Int) -> Void
 
-        var body: Never {
-            bodyException()
-        }
-
-        static func _makeProperty(
-            property: _GraphValue<EnvironmentTests.IntegerReceiver>,
-            inputs: _PropertyInputs
-        ) async throws -> _PropertyOutputs {
-            property.assertPathway()
-            property.value(inputs.environment.integer)
-            return .init(EmptyLeaf())
+        var body: EmptyProperty {
+            value(integer)
+            return EmptyProperty()
         }
     }
 


### PR DESCRIPTION
## Description

Added the `@Environment` property wrapper to allow custom `Property` implementations to obtain values from the environment, both by default from `RequestDL` or by using the `environment(_:_:)` method.

Currently, there are no publicly available properties within `EnvironmentValues`. However, this implementation opens up the possibility for new features that may explore this implementation.

Fixes **None**

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added/updated necessary comments/documentation.
