### PR TITLE
Implemented `@Namespace`

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Environment/Models/PropertyEnvironmentUpdater.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Environment/Models/PropertyEnvironmentUpdater.swift
@@ -15,8 +15,8 @@ struct PropertyEnvironmentUpdater<Content> {
     func callAsFunction(_ values: EnvironmentValues) {
         let mirror = PropertyMirror(content)
 
-        for propertyValue in mirror() {
-            if let environment = propertyValue as? EnvironmentPropertyValue {
+        for child in mirror() {
+            if let environment = child.value as? EnvironmentPropertyValue {
                 environment.setValue(for: values)
             }
         }

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Modifier/ModifiedProperty.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Modifier/ModifiedProperty.swift
@@ -33,7 +33,7 @@ private struct ModifiedProperty<Content: Property, Modifier: PropertyModifier>: 
             content: property.modifier
         )
 
-        updater(inputs)
+        let inputs = updater(inputs)
 
         let id = ObjectIdentifier(Modifier.Body.self)
         let content = property.modifier.body(content: modifiedContent)

--- a/Sources/RequestDL/Properties/Sources/Graph/Graph/Models/IdentifiedGraphValue.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Graph/Models/IdentifiedGraphValue.swift
@@ -1,0 +1,51 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+protocol IdentifiedGraphValue {
+
+    var id: AnyHashable { get }
+    var nextID: AnyHashable? { get }
+
+    var previousValue: IdentifiedGraphValue? { get }
+}
+
+extension IdentifiedGraphValue {
+
+    var pathwayHashValue: Int {
+        guard let previousValue else {
+            return id.hashValue
+        }
+
+        let graph = sequence(first: previousValue, next: { $0.previousValue })
+        var hashes = [AnyHashable]()
+
+        for value in graph {
+            if let nextID = value.nextID {
+                hashes.append(nextID)
+            } else if value.previousValue == nil {
+                hashes.append(value.id)
+            } else {
+                break
+            }
+        }
+
+        return hashes.hashValue
+    }
+
+    func assertPathway() {
+        guard let previousValue else {
+            return
+        }
+
+        if previousValue.nextID == id {
+            return
+        }
+
+        Internals.Log.failure(
+            .unexpectedGraphPathway()
+        )
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Graph/Resolve/Models/PropertyInputs.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Resolve/Models/PropertyInputs.swift
@@ -7,10 +7,12 @@ import Foundation
 public struct _PropertyInputs {
 
     var environment: EnvironmentValues
+    var namespaceID: Namespace.ID
 
     init(
         environment: EnvironmentValues
     ) {
         self.environment = environment
+        self.namespaceID = .global
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Property.swift
+++ b/Sources/RequestDL/Properties/Sources/Property.swift
@@ -59,7 +59,7 @@ extension Property {
         property.assertPathway()
 
         let updater = GraphValueUpdater(property)
-        updater(inputs)
+        let inputs = updater(inputs)
 
         return try await Body._makeProperty(
             property: property.body,

--- a/Sources/RequestDL/Properties/Sources/Value/Namespace/Models/PropertyNamespaceUpdater.swift
+++ b/Sources/RequestDL/Properties/Sources/Value/Namespace/Models/PropertyNamespaceUpdater.swift
@@ -1,0 +1,39 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+struct PropertyNamespaceUpdater<Content> {
+
+    private let content: Content
+
+    init(_ content: Content) {
+        self.content = content
+    }
+
+    func callAsFunction(_ hashValue: Int) -> Namespace.ID? {
+        let mirror = PropertyMirror(content)
+
+        var labels = [String]()
+        var latestID: Namespace.ID?
+
+        for child in mirror() {
+            guard let namespace = child.value as? Namespace else {
+                continue
+            }
+
+            labels.append(child.label ?? "nil")
+            let namespaceID = Namespace.ID(
+                base: Content.self,
+                namespace: labels.joined(separator: "."),
+                hashValue: hashValue
+            )
+
+            namespace._namespaceID = namespaceID
+            latestID = namespaceID
+        }
+
+        return latestID
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Value/Namespace/Namespace.swift
+++ b/Sources/RequestDL/Properties/Sources/Value/Namespace/Namespace.swift
@@ -1,0 +1,46 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+@propertyWrapper
+public struct Namespace: PropertyValue {
+
+    @PropertyContainer var _namespaceID: ID?
+
+    public init() {}
+
+    public var wrappedValue: ID {
+        _namespaceID ?? .global
+    }
+}
+
+extension Namespace {
+
+    public struct ID: Hashable {
+
+        private let rawValue: String
+
+        init<Base>(
+            base: Base.Type,
+            namespace: String,
+            hashValue: Int
+        ) {
+            self.rawValue = "\(base).\(namespace):\(hashValue)"
+        }
+    }
+}
+
+extension Namespace.ID {
+
+    private enum Global {}
+
+    static var global: Self {
+        .init(
+            base: Global.self,
+            namespace: "_global",
+            hashValue: .zero
+        )
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Value/Property Value/Model/GraphValueUpdater.swift
+++ b/Sources/RequestDL/Properties/Sources/Value/Property Value/Model/GraphValueUpdater.swift
@@ -22,8 +22,17 @@ struct GraphValueUpdater<Content> {
         self.content = content
     }
 
-    func callAsFunction(_ inputs: _PropertyInputs) {
+    func callAsFunction(_ inputs: _PropertyInputs) -> _PropertyInputs {
+        var inputs = inputs
+
         let environmentUpdater = PropertyEnvironmentUpdater(content)
         environmentUpdater(inputs.environment)
+
+        let namespaceUpdater = PropertyNamespaceUpdater(content)
+        if let namespaceID = namespaceUpdater(hashValue) {
+            inputs.namespaceID = namespaceID
+        }
+
+        return inputs
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Value/Property Value/Model/PropertyMirror.swift
+++ b/Sources/RequestDL/Properties/Sources/Value/Property Value/Model/PropertyMirror.swift
@@ -12,9 +12,22 @@ struct PropertyMirror<Content> {
         self.content = content
     }
 
-    func callAsFunction() -> [PropertyValue] {
-        Mirror(reflecting: content).children.compactMap {
-            $0.value as? PropertyValue
+    func callAsFunction() -> [Child] {
+        Mirror(reflecting: content).children.compactMap { child in
+            (child.value as? PropertyValue).map {
+                .init(
+                    label: child.label,
+                    value: $0
+                )
+            }
         }
+    }
+}
+
+extension PropertyMirror {
+
+    struct Child {
+        let label: String?
+        let value: PropertyValue
     }
 }

--- a/Tests/RequestDLTests/Properties/Sources/Extra Properties/Namespace/NamespaceTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Extra Properties/Namespace/NamespaceTests.swift
@@ -1,0 +1,172 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+import XCTest
+@testable @_spi(Private) import RequestDL
+
+class NamespaceTests: XCTestCase {
+
+    struct NamespaceSpy: Property {
+
+        let callback: (Int, Namespace.ID) -> Void
+
+        var body: Never {
+            bodyException()
+        }
+
+        static func _makeProperty(
+            property: _GraphValue<NamespaceTests.NamespaceSpy>,
+            inputs: _PropertyInputs
+        ) async throws -> _PropertyOutputs {
+            let hashValue = property._identified.previousValue?.previousValue?.pathwayHashValue ?? {
+                property.pathwayHashValue
+            }()
+
+            property.callback(hashValue, inputs.namespaceID)
+
+            return .init(EmptyLeaf())
+        }
+    }
+
+    func testNamespace_whenNotSet() async throws {
+        // Given
+        var namespaceID: Namespace.ID?
+
+        // When
+        _ = try await resolve(TestProperty {
+            NamespaceSpy {
+                namespaceID = $1
+            }
+        })
+
+        // Then
+        XCTAssertEqual(namespaceID, .global)
+    }
+}
+
+extension NamespaceTests {
+
+    struct SingleNamespace<Content: Property>: Property {
+
+        @Namespace var projectNamespace
+
+        let content: Content
+
+        init(@PropertyBuilder content: () -> Content) {
+            self.content = content()
+        }
+
+        var body: some Property {
+            content
+            Path("v1")
+        }
+    }
+
+    func testNamespace_whenSet() async throws {
+        // Given
+        var namespaceID: Namespace.ID?
+        var hashValue: Int = .zero
+
+        // When
+        _ = try await resolve(TestProperty {
+            SingleNamespace {
+                NamespaceSpy {
+                    hashValue = $0
+                    namespaceID = $1
+                }
+            }
+        })
+
+        // Then
+        XCTAssertEqual(namespaceID, Namespace.ID(
+            base: SingleNamespace<NamespaceSpy>.self,
+            namespace: "_projectNamespace",
+            hashValue: hashValue
+        ))
+    }
+}
+
+extension NamespaceTests {
+
+    struct MultipleNamespace<Content: Property>: Property {
+
+        @Namespace var multiple
+        @Namespace var namespace
+
+        let content: Content
+
+        init(@PropertyBuilder content: () -> Content) {
+            self.content = content()
+            print(self)
+        }
+
+        var body: some Property {
+            content
+            Path("v1")
+        }
+    }
+
+    func testNamespace_whenSetWithMultiple() async throws {
+        // Given
+        var namespaceID: Namespace.ID?
+        var hashValue: Int = .zero
+
+        // When
+        _ = try await resolve(TestProperty {
+            MultipleNamespace {
+                NamespaceSpy {
+                    hashValue = $0
+                    namespaceID = $1
+                }
+            }
+        })
+
+        // Then
+        XCTAssertEqual(namespaceID, Namespace.ID(
+            base: MultipleNamespace<NamespaceSpy>.self,
+            namespace: "_multiple._namespace",
+            hashValue: hashValue
+        ))
+    }
+}
+
+extension NamespaceTests {
+
+    struct NamespaceModifier: PropertyModifier {
+
+        @Namespace var namespace
+
+        let callback: (Int, Namespace.ID) -> Void
+
+        func body(content: Content) -> some Property {
+            content
+            NamespaceSpy(callback: callback)
+        }
+    }
+
+    func testNamespace_whenModifier() async throws {
+        // Given
+        var namespaceID: Namespace.ID?
+        var hashValue: Int = .zero
+
+        // When
+        _ = try await resolve(TestProperty {
+            Path("v1")
+                .modifier(NamespaceModifier {
+                    hashValue = $0
+                    namespaceID = $1
+                })
+        })
+
+        // Then
+        XCTAssertEqual(namespaceID, Namespace.ID(
+            base: NamespaceModifier.self,
+            namespace: "_namespace",
+            hashValue: hashValue
+        ))
+    }
+}
+
+


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

Implemented the `@Namespace` to integrate with planned changes that will allow `Property` to store values using `@StoredObject` (not yet available).

The purpose of `@Namespace` is to define a scope for all properties within the object. This will help create references to objects and prevent them from colliding, although this is unlikely.

Considering only this PR does not provide a complete view of the changes.

Example:

```swift
struct MyCompanyConfiguration: Property {

    @Namespace var myCompany

    var body: some Property {
        Headers...
    }
}
```

With this, everything included by `MyCompanyConfiguration` will be automatically identified internally as a property of the namespace `_myCompany`. This will be leveraged by `@StoredObject`.

Fixes **None**

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
