### PR TITLE
Refactor Node integration with _PropertyOutput

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Empty/EmptyProperty.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Empty/EmptyProperty.swift
@@ -26,6 +26,6 @@ extension EmptyProperty {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
-        return .init(EmptyLeaf())
+        return .empty
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/ForEach/ForEach.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/ForEach/ForEach.swift
@@ -144,6 +144,6 @@ extension ForEach {
             group.append(output.node)
         }
 
-        return .init(group)
+        return .children(group)
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Group/Group.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Group/Group.swift
@@ -50,13 +50,9 @@ extension Group {
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
 
-        let output = try await Content._makeProperty(
+        return try await Content._makeProperty(
             property: property.content,
             inputs: inputs
         )
-
-        var children = ChildrenNode()
-        children.append(output.node)
-        return .init(children)
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Graph/Empty/EmptyLeafNode.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Empty/EmptyLeafNode.swift
@@ -1,0 +1,15 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+@RequestActor
+struct EmptyLeafNode: Node {
+
+    init() {}
+
+    mutating func next() -> Node? {
+        nil
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Graph/Leaf/LeafNode.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Leaf/LeafNode.swift
@@ -6,7 +6,7 @@ import Foundation
 
 @dynamicMemberLookup
 @RequestActor
-struct Leaf<Property: PropertyNode>: Node {
+struct LeafNode<Property: PropertyNode>: Node {
 
     private let property: Property
 
@@ -23,14 +23,14 @@ struct Leaf<Property: PropertyNode>: Node {
     }
 }
 
-extension Leaf: PropertyNode {
+extension LeafNode: PropertyNode {
 
     func make(_ make: inout Make) async throws {
         try await property.make(&make)
     }
 }
 
-extension Leaf {
+extension LeafNode {
 
     private var propertyDescription: String {
         "property = \(property.nodeDescription)"
@@ -40,14 +40,5 @@ extension Leaf {
         let title = String(describing: type(of: self))
         let values = propertyDescription.debug_shiftLines()
         return "\(title) {\n\(values)\n}"
-    }
-}
-
-struct EmptyLeaf: Node {
-
-    init() {}
-
-    mutating func next() -> Node? {
-        nil
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Graph/Node/Node.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Node/Node.swift
@@ -14,8 +14,8 @@ extension Node {
 
     func first<Property: PropertyNode>(
         of propertyNode: Property.Type
-    ) -> Leaf<Property>? {
-        if let leaf = self as? Leaf<Property> {
+    ) -> LeafNode<Property>? {
+        if let leaf = self as? LeafNode<Property> {
             return leaf
         }
 
@@ -32,13 +32,13 @@ extension Node {
 
     func search<Property: PropertyNode>(
         for propertyNode: Property.Type
-    ) -> [Leaf<Property>] {
-        if let leaf = self as? Leaf<Property> {
+    ) -> [LeafNode<Property>] {
+        if let leaf = self as? LeafNode<Property> {
             return [leaf]
         }
 
         var mutableSelf = self
-        var items = [Leaf<Property>]()
+        var items = [LeafNode<Property>]()
 
         while let node = mutableSelf.next() {
             items.append(contentsOf: node.search(for: propertyNode))
@@ -47,6 +47,7 @@ extension Node {
         return items
     }
 }
+
 
 extension Node {
 

--- a/Sources/RequestDL/Properties/Sources/Graph/Resolve/Models/PropertyOutputs.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Resolve/Models/PropertyOutputs.swift
@@ -12,3 +12,19 @@ public struct _PropertyOutputs {
         self.node = node
     }
 }
+
+@RequestActor
+extension _PropertyOutputs {
+
+    static var empty: Self {
+        .init(EmptyLeafNode())
+    }
+
+    static func leaf<Property: PropertyNode>(_ property: Property) -> Self {
+        .init(LeafNode(property))
+    }
+
+    static func children(_ children: ChildrenNode) -> Self {
+        .init(children)
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Graph/Resolve/Models/PropertyOutputs.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Resolve/Models/PropertyOutputs.swift
@@ -8,7 +8,7 @@ public struct _PropertyOutputs {
 
     let node: Node
 
-    init(_ node: Node) {
+    fileprivate init(_ node: Node) {
         self.node = node
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Authorization/Authorization.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Authorization/Authorization.swift
@@ -62,9 +62,9 @@ extension Authorization {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
-        return .init(Leaf(Node(
+        return .leaf(Node(
             type: property.type,
             token: property.token
-        )))
+        ))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Header Group/HeaderGroup.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Header Group/HeaderGroup.swift
@@ -59,7 +59,7 @@ extension HeaderGroup {
 
     private struct Node: PropertyNode {
 
-        let nodes: [Leaf<Headers.Node>]
+        let nodes: [LeafNode<Headers.Node>]
 
         func make(_ make: inout Make) async throws {
             for node in nodes {
@@ -81,6 +81,6 @@ extension HeaderGroup {
             inputs: inputs
         )
 
-        return .init(Leaf(Node(nodes: outputs.node.search(for: Headers.Node.self))))
+        return .leaf(Node(nodes: outputs.node.search(for: Headers.Node.self)))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept/Headers.Accept.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept/Headers.Accept.swift
@@ -39,9 +39,9 @@ extension Headers.Accept {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
-        return .init(Leaf(Headers.Node(
+        return .leaf(Headers.Node(
             property.type.rawValue,
             forKey: "Accept"
-        )))
+        ))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Any/Headers.Any.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Any/Headers.Any.swift
@@ -41,9 +41,9 @@ extension Headers.`Any` {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
-        return .init(Leaf(Headers.Node(
+        return .leaf(Headers.Node(
             property.value,
             forKey: property.key
-        )))
+        ))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Cache/Headers.Cache.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Cache/Headers.Cache.swift
@@ -69,10 +69,10 @@ extension Headers.Cache {
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
 
-        return .init(Leaf(Headers.Node(
+        return .leaf(Headers.Node(
             property.contents.joined(separator: ", "),
             forKey: "Cache-Control"
-        )))
+        ))
     }
 }
 

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Content Length/Headers.ContentLength.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Content Length/Headers.ContentLength.swift
@@ -37,9 +37,9 @@ extension Headers.ContentLength {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
-        return .init(Leaf(Headers.Node(
+        return .leaf(Headers.Node(
             property.bytes,
             forKey: "Content-Length"
-        )))
+        ))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Content Type/Headers.ContentType.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Content Type/Headers.ContentType.swift
@@ -37,11 +37,11 @@ extension Headers.ContentType {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
-        return .init(Leaf(
+        return .leaf(
             Headers.Node(
                 property.contentType.rawValue,
                 forKey: "Content-Type"
             )
-        ))
+        )
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Host/Headers.Host.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Host/Headers.Host.swift
@@ -52,9 +52,9 @@ extension Headers.Host {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
-        return .init(Leaf(Headers.Node(
+        return .leaf(Headers.Node(
             property.value,
             forKey: "Host"
-        )))
+        ))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Origin/Headers.Origin.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Origin/Headers.Origin.swift
@@ -64,9 +64,9 @@ extension Headers.Origin {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
-        return .init(Leaf(Headers.Node(
+        return .leaf(Headers.Node(
             property.value,
             forKey: "Origin"
-        )))
+        ))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Referer/Headers.Referer.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Referer/Headers.Referer.swift
@@ -46,9 +46,9 @@ extension Headers.Referer {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
-        return .init(Leaf(Headers.Node(
+        return .leaf(Headers.Node(
             property.value,
             forKey: "Referer"
-        )))
+        ))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Method/RequestMethod.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Method/RequestMethod.swift
@@ -62,8 +62,8 @@ extension RequestMethod {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
-        return .init(Leaf(Node(
+        return .leaf(Node(
             httpMethod: property.httpMethod.rawValue
-        )))
+        ))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Reading Mode/ReadingMode.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Reading Mode/ReadingMode.swift
@@ -60,6 +60,6 @@ extension ReadingMode {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
-        return .init(Leaf(Node(mode: property.mode)))
+        return .leaf(Node(mode: property.mode))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Session/Session.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Session/Session.swift
@@ -197,9 +197,9 @@ extension Session {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
-        return .init(Leaf(Node(
+        return .leaf(Node(
             configuration: property.configuration,
             provider: property.provider
-        )))
+        ))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Timeout/Timeout.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Timeout/Timeout.swift
@@ -83,9 +83,9 @@ extension Timeout {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
-        return .init(Leaf(Node(
+        return .leaf(Node(
             timeout: property.timeout,
             source: property.source
-        )))
+        ))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form Data/FormData.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form Data/FormData.swift
@@ -72,7 +72,7 @@ extension FormData {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
-        return .init(Leaf(FormNode {
+        return .leaf(FormNode {
             PartFormRawValue(property.buffer.getData() ?? Data(), forHeaders: [
                 kContentDisposition: kContentDispositionValue(
                     property.fileName,
@@ -80,6 +80,6 @@ extension FormData {
                 ),
                 "Content-Type": property.contentType
             ])
-        }))
+        })
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form File/FormFile.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form File/FormFile.swift
@@ -77,7 +77,7 @@ extension FormFile {
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
 
-        return .init(Leaf(FormNode {
+        return .leaf(FormNode {
             let data = (try? Data(contentsOf: property.url)) ?? Data()
             return PartFormRawValue(data, forHeaders: [
                 kContentDisposition: kContentDispositionValue(
@@ -86,6 +86,6 @@ extension FormFile {
                 ),
                 "Content-Type": property.contentType
             ])
-        }))
+        })
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form Group/FormGroup.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form Group/FormGroup.swift
@@ -45,7 +45,7 @@ extension FormGroup {
 
     private struct Node: PropertyNode {
 
-        let nodes: [Leaf<FormNode>]
+        let nodes: [LeafNode<FormNode>]
 
         func make(_ make: inout Make) async throws {
             let multipart = nodes.map(\.factory).map { $0() }
@@ -78,6 +78,6 @@ extension FormGroup {
 
         let nodes = outputs.node.search(for: FormNode.self)
 
-        return .init(Leaf(Node(nodes: nodes)))
+        return .leaf(Node(nodes: nodes))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form Value/FormValue.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form Value/FormValue.swift
@@ -46,13 +46,13 @@ extension FormValue {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
-        return .init(Leaf(FormNode {
+        return .leaf(FormNode {
             PartFormRawValue(Data("\(property.value)".utf8), forHeaders: [
                 kContentDisposition: kContentDispositionValue(
                     nil,
                     forKey: property.key
                 )
             ])
-        }))
+        })
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload/Payload.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload/Payload.swift
@@ -140,8 +140,8 @@ extension Payload {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
-        return .init(Leaf(Node {
+        return .leaf(Node {
             property.source(property.provider)
-        }))
+        })
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Result Builder/Optional/_OptionalContent.swift
+++ b/Sources/RequestDL/Properties/Sources/Result Builder/Optional/_OptionalContent.swift
@@ -37,7 +37,7 @@ extension _OptionalContent {
 
         switch property.source {
         case .none:
-            return .init(EmptyLeaf())
+            return .empty
         case .some:
             return try await Content._makeProperty(
                 property: property.content,

--- a/Sources/RequestDL/Properties/Sources/Result Builder/Partial/_PartialContent.swift
+++ b/Sources/RequestDL/Properties/Sources/Result Builder/Partial/_PartialContent.swift
@@ -43,6 +43,6 @@ extension _PartialContent {
         children.append(accumulatedOutput.node)
         children.append(nextOutput.node)
 
-        return .init(children)
+        return .children(children)
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Additional Trusts/AdditionalTrusts.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Additional Trusts/AdditionalTrusts.swift
@@ -99,7 +99,7 @@ extension AdditionalTrusts {
         enum Source {
             case file(String)
             case bytes([UInt8])
-            case nodes([Leaf<SecureConnectionNode>])
+            case nodes([LeafNode<SecureConnectionNode>])
         }
 
         let source: Source
@@ -134,13 +134,13 @@ extension AdditionalTrusts {
 
         switch property.source {
         case .file(let file):
-            return .init(Leaf(SecureConnectionNode(
+            return .leaf(SecureConnectionNode(
                 Node(source: .file(file))
-            )))
+            ))
         case .bytes(let bytes):
-            return .init(Leaf(SecureConnectionNode(
+            return .leaf(SecureConnectionNode(
                 Node(source: .bytes(bytes))
-            )))
+            ))
         case .content:
             var inputs = inputs
             inputs.environment.certificateProperty = .additionalTrust
@@ -150,12 +150,12 @@ extension AdditionalTrusts {
                 inputs: inputs
             )
 
-            return .init(Leaf(SecureConnectionNode(
+            return .leaf(SecureConnectionNode(
                 Node(source: .nodes(outputs.node
                     .search(for: SecureConnectionNode.self)
                     .filter { $0.contains(CertificateNode.self) }
                 ))
-            )))
+            ))
         }
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Certificate/Certificate.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Certificate/Certificate.swift
@@ -82,13 +82,13 @@ extension Certificate {
             )
         }
 
-        return .init(Leaf(SecureConnectionNode(
+        return .leaf(SecureConnectionNode(
             CertificateNode(
                 source: property.source,
                 property: certificateProperty,
                 format: property.format()
             )
-        )))
+        ))
     }
 }
 

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Certificates/Certificates.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Certificates/Certificates.swift
@@ -101,7 +101,7 @@ extension Certificates {
         enum Source {
             case file(String)
             case bytes([UInt8])
-            case nodes([Leaf<SecureConnectionNode>])
+            case nodes([LeafNode<SecureConnectionNode>])
         }
 
         let source: Source
@@ -132,13 +132,13 @@ extension Certificates {
 
         switch property.source {
         case .file(let file):
-            return .init(Leaf(SecureConnectionNode(
+            return .leaf(SecureConnectionNode(
                 Node(source: .file(file))
-            )))
+            ))
         case .bytes(let bytes):
-            return .init(Leaf(SecureConnectionNode(
+            return .leaf(SecureConnectionNode(
                 Node(source: .bytes(bytes))
-            )))
+            ))
         case .content:
             var inputs = inputs
             inputs.environment.certificateProperty = .chain
@@ -148,12 +148,12 @@ extension Certificates {
                 inputs: inputs
             )
 
-            return .init(Leaf(SecureConnectionNode(
+            return .leaf(SecureConnectionNode(
                 Node(source: .nodes(outputs.node
                     .search(for: SecureConnectionNode.self)
                     .filter { $0.contains(CertificateNode.self) }
                 ))
-            )))
+            ))
         }
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/PSK/PSKIdentity.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/PSK/PSKIdentity.swift
@@ -82,12 +82,12 @@ extension PSKIdentity {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
-        return .init(Leaf(SecureConnectionNode(
+        return .leaf(SecureConnectionNode(
             Node(
                 source: property.source,
                 hint: property.hint
             )
-        )))
+        ))
     }
 }
 

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Private Key/PrivateKey.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Private Key/PrivateKey.swift
@@ -233,8 +233,8 @@ extension PrivateKey {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
-        return .init(Leaf(SecureConnectionNode(
+        return .leaf(SecureConnectionNode(
             Node(source: property.source)
-        )))
+        ))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/SecureConnection.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/SecureConnection.swift
@@ -242,7 +242,7 @@ extension SecureConnection {
     private struct Node: PropertyNode {
 
         let secureConnection: Internals.SecureConnection
-        let nodes: [Leaf<SecureConnectionNode>]
+        let nodes: [LeafNode<SecureConnectionNode>]
 
         func make(_ make: inout Make) async throws {
             make.configuration.secureConnection = secureConnection
@@ -266,9 +266,9 @@ extension SecureConnection {
             inputs: inputs
         )
 
-        return .init(Leaf(Node(
+        return .leaf(Node(
             secureConnection: property.secureConnection,
             nodes: outputs.node.search(for: SecureConnectionNode.self)
-        )))
+        ))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Trusts/DefaultTrusts.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Trusts/DefaultTrusts.swift
@@ -37,6 +37,6 @@ extension DefaultTrusts {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
-        return .init(Leaf(SecureConnectionNode(Node())))
+        return .leaf(SecureConnectionNode(Node()))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Trusts/Trusts.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Trusts/Trusts.swift
@@ -99,7 +99,7 @@ extension Trusts {
         enum Source {
             case file(String)
             case bytes([UInt8])
-            case nodes([Leaf<SecureConnectionNode>])
+            case nodes([LeafNode<SecureConnectionNode>])
         }
 
         let source: Source
@@ -130,13 +130,13 @@ extension Trusts {
 
         switch property.source {
         case .file(let file):
-            return .init(Leaf(SecureConnectionNode(
+            return .leaf(SecureConnectionNode(
                 Node(source: .file(file))
-            )))
+            ))
         case .bytes(let bytes):
-            return .init(Leaf(SecureConnectionNode(
+            return .leaf(SecureConnectionNode(
                 Node(source: .bytes(bytes))
-            )))
+            ))
         case .content:
             var inputs = inputs
             inputs.environment.certificateProperty = .trust
@@ -146,12 +146,12 @@ extension Trusts {
                 inputs: inputs
             )
 
-            return .init(Leaf(SecureConnectionNode(
+            return .leaf(SecureConnectionNode(
                 Node(source: .nodes(outputs.node
                     .search(for: SecureConnectionNode.self)
                     .filter { $0.contains(CertificateNode.self) }
                 ))
-            )))
+            ))
         }
     }
 }

--- a/Sources/RequestDL/Properties/Sources/URL/Path/Path.swift
+++ b/Sources/RequestDL/Properties/Sources/URL/Path/Path.swift
@@ -99,6 +99,6 @@ extension Path {
 
         let path = property.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
 
-        return .init(Leaf(Node(path: path)))
+        return .leaf(Node(path: path))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/URL/Query Group/QueryGroup.swift
+++ b/Sources/RequestDL/Properties/Sources/URL/Query Group/QueryGroup.swift
@@ -54,9 +54,9 @@ extension QueryGroup {
 
     struct Node: PropertyNode {
 
-        let leafs: [Leaf<Query.Node>]
+        let leafs: [LeafNode<Query.Node>]
 
-        fileprivate init(_ leafs: [Leaf<Query.Node>]) {
+        fileprivate init(_ leafs: [LeafNode<Query.Node>]) {
             self.leafs = leafs
         }
 
@@ -80,6 +80,6 @@ extension QueryGroup {
             inputs: inputs
         )
 
-        return .init(Leaf(Node(output.node.search(for: Query.Node.self))))
+        return .leaf(Node(output.node.search(for: Query.Node.self)))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/URL/Query/Query.swift
+++ b/Sources/RequestDL/Properties/Sources/URL/Query/Query.swift
@@ -71,9 +71,9 @@ extension Query {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
-        return .init(Leaf(Node(
+        return .leaf(Node(
             key: property.key,
             value: "\(property.value)"
-        )))
+        ))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/URL/URL/BaseURL.swift
+++ b/Sources/RequestDL/Properties/Sources/URL/URL/BaseURL.swift
@@ -141,6 +141,6 @@ extension BaseURL {
             )
         }
 
-        return .init(Leaf(Node(baseURL)))
+        return .leaf(Node(baseURL))
     }
 }

--- a/Tests/RequestDLTests/Properties/Sources/Extra Properties/Namespace/NamespaceTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Extra Properties/Namespace/NamespaceTests.swift
@@ -28,7 +28,7 @@ class NamespaceTests: XCTestCase {
 
             property.callback(hashValue, inputs.namespaceID)
 
-            return .init(EmptyLeaf())
+            return .empty
         }
     }
 

--- a/Tests/RequestDLTests/Properties/Sources/Graph/Resolve/ResolveTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Graph/Resolve/ResolveTests.swift
@@ -95,36 +95,36 @@ extension ResolveTests {
         """
         Resolve {
             ChildrenNode {
-                Leaf<Node> {
+                LeafNode<Node> {
                     property = Node {
                         baseURL = https://apple.com
                     }
                 },
-                Leaf<Node> {
+                LeafNode<Node> {
                     property = Node {
                         path = api
                     }
                 },
-                Leaf<Node> {
+                LeafNode<Node> {
                     property = Node {
                         path = v2
                     }
                 },
-                Leaf<Node> {
+                LeafNode<Node> {
                     property = Node {
                         key = Accept,
                         value = application/json,
                         next = nil
                     }
                 },
-                Leaf<Node> {
+                LeafNode<Node> {
                     property = Node {
                         key = Content-Type,
                         value = application/json,
                         next = nil
                     }
                 },
-                Leaf<Node> {
+                LeafNode<Node> {
                     property = Node {
                         timeout = UnitTime {
                             nanoseconds = 60
@@ -134,7 +134,7 @@ extension ResolveTests {
                         }
                     }
                 },
-                Leaf<Node> {
+                LeafNode<Node> {
                     property = Node {
                         configuration = Configuration {
                             secureConnection = nil,
@@ -174,32 +174,32 @@ extension ResolveTests {
         """
         Resolve {
             ChildrenNode {
-                Leaf<Node> {
+                LeafNode<Node> {
                     property = Node {
                         baseURL = https://apple.com
                     }
                 },
-                Leaf<Node> {
+                LeafNode<Node> {
                     property = Node {
                         path = api
                     }
                 },
-                Leaf<Node> {
+                LeafNode<Node> {
                     property = Node {
                         path = v2
                     }
                 },
-                Leaf<Node> {
+                LeafNode<Node> {
                     property = Node {
                         nodes = [
-                            Leaf<Node> {
+                            LeafNode<Node> {
                                 property = Node {
                                     key = Accept,
                                     value = application/json,
                                     next = nil
                                 }
                             },
-                            Leaf<Node> {
+                            LeafNode<Node> {
                                 property = Node {
                                     key = Content-Type,
                                     value = application/json,
@@ -209,10 +209,10 @@ extension ResolveTests {
                         ]
                     }
                 },
-                Leaf<Node> {
+                LeafNode<Node> {
                     property = Node {
                         leafs = [
-                            Leaf<Node> {
+                            LeafNode<Node> {
                                 property = Node {
                                     key = q,
                                     value = some question
@@ -230,12 +230,12 @@ extension ResolveTests {
         """
         Resolve {
             ChildrenNode {
-                Leaf<Node> {
+                LeafNode<Node> {
                     property = Node {
                         baseURL = https://apple.com
                     }
                 },
-                Leaf<Node> {
+                LeafNode<Node> {
                     property = Node {
                         secureConnection = SecureConnection {
                             context = .client,
@@ -260,13 +260,13 @@ extension ResolveTests {
                             cipherSuiteValues = nil
                         },
                         nodes = [
-                            Leaf<SecureConnectionNode> {
+                            LeafNode<SecureConnectionNode> {
                                 property = SecureConnectionNode {
                                     source = Source.node(
                                         Node {
                                             source = Source.nodes(
                                                 [
-                                                    Leaf<SecureConnectionNode> {
+                                                    LeafNode<SecureConnectionNode> {
                                                         property = SecureConnectionNode {
                                                             source = Source.collectorNode(
                                                                 CertificateNode {
@@ -283,13 +283,13 @@ extension ResolveTests {
                                     )
                                 }
                             },
-                            Leaf<SecureConnectionNode> {
+                            LeafNode<SecureConnectionNode> {
                                 property = SecureConnectionNode {
                                     source = Source.node(
                                         Node {
                                             source = Source.nodes(
                                                 [
-                                                    Leaf<SecureConnectionNode> {
+                                                    LeafNode<SecureConnectionNode> {
                                                         property = SecureConnectionNode {
                                                             source = Source.collectorNode(
                                                                 CertificateNode {
@@ -300,7 +300,7 @@ extension ResolveTests {
                                                             )
                                                         }
                                                     },
-                                                    Leaf<SecureConnectionNode> {
+                                                    LeafNode<SecureConnectionNode> {
                                                         property = SecureConnectionNode {
                                                             source = Source.collectorNode(
                                                                 CertificateNode {
@@ -317,13 +317,13 @@ extension ResolveTests {
                                     )
                                 }
                             },
-                            Leaf<SecureConnectionNode> {
+                            LeafNode<SecureConnectionNode> {
                                 property = SecureConnectionNode {
                                     source = Source.node(
                                         Node {
                                             source = Source.nodes(
                                                 [
-                                                    Leaf<SecureConnectionNode> {
+                                                    LeafNode<SecureConnectionNode> {
                                                         property = SecureConnectionNode {
                                                             source = Source.collectorNode(
                                                                 CertificateNode {
@@ -334,7 +334,7 @@ extension ResolveTests {
                                                             )
                                                         }
                                                     },
-                                                    Leaf<SecureConnectionNode> {
+                                                    LeafNode<SecureConnectionNode> {
                                                         property = SecureConnectionNode {
                                                             source = Source.collectorNode(
                                                                 CertificateNode {
@@ -354,7 +354,7 @@ extension ResolveTests {
                         ]
                     }
                 },
-                Leaf<SecureConnectionNode> {
+                LeafNode<SecureConnectionNode> {
                     property = SecureConnectionNode {
                         source = Source.node(
                             Node {


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

The creation of nodes has been integrated directly through _PropertyOutputs to make the API and internal use of objects more consistent. This change will make the RequestDL development process faster and cleaner.

Fixes **None**

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
