### PR TITLE
Updated PartialContent and ChildrenNode to group when needed

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Graph/Children/ChildrenNode.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Children/ChildrenNode.swift
@@ -11,8 +11,8 @@ struct ChildrenNode: Node {
 
     init() {}
 
-    mutating func append(_ node: Node) {
-        if let group = node as? ChildrenNode {
+    mutating func append(_ node: Node, grouping: Bool = false) {
+        if grouping, let group = node as? ChildrenNode {
             nodes.append(contentsOf: group.nodes)
         } else {
             nodes.append(node)

--- a/Sources/RequestDL/Properties/Sources/Result Builder/Partial/_PartialContent.swift
+++ b/Sources/RequestDL/Properties/Sources/Result Builder/Partial/_PartialContent.swift
@@ -28,21 +28,32 @@ extension _PartialContent {
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
 
-        let accumulatedOutput = try await Accumulated._makeProperty(
+        let accumulated = try await Accumulated._makeProperty(
             property: property.accumulated,
             inputs: inputs
         )
 
-        let nextOutput = try await Next._makeProperty(
+        let next = try await Next._makeProperty(
             property: property.next,
             inputs: inputs
         )
 
         var children = ChildrenNode()
 
-        children.append(accumulatedOutput.node)
-        children.append(nextOutput.node)
+        children.append(accumulated.node, grouping: property.accumulated.isPartialContent)
+        children.append(next.node)
 
         return .init(children)
+    }
+}
+
+private protocol _PartialContentReference {}
+
+extension _PartialContent: _PartialContentReference {}
+
+extension Property {
+
+    fileprivate var isPartialContent: Bool {
+        self is _PartialContentReference
     }
 }


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

We found that the way ChildrenNode was grouping nodes was incorrect and not representing the Property graph structure correctly. To address this, we added a grouping parameter and implemented protocols to determine when PartialContent should be grouped or not.

Fixes **None**

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
