### PR TITLE
Removed next from Headers.Node

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept/Headers.Accept.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept/Headers.Accept.swift
@@ -40,8 +40,8 @@ extension Headers.Accept {
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
         return .leaf(Headers.Node(
-            property.type.rawValue,
-            forKey: "Accept"
+            key: "Accept",
+            value: property.type.rawValue
         ))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Any/Headers.Any.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Any/Headers.Any.swift
@@ -42,8 +42,8 @@ extension Headers.`Any` {
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
         return .leaf(Headers.Node(
-            property.value,
-            forKey: property.key
+            key: property.key,
+            value: property.value
         ))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Cache/Headers.Cache.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Cache/Headers.Cache.swift
@@ -70,8 +70,8 @@ extension Headers.Cache {
         property.assertPathway()
 
         return .leaf(Headers.Node(
-            property.contents.joined(separator: ", "),
-            forKey: "Cache-Control"
+            key: "Cache-Control",
+            value: property.contents.joined(separator: ", ")
         ))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Content Length/Headers.ContentLength.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Content Length/Headers.ContentLength.swift
@@ -38,8 +38,8 @@ extension Headers.ContentLength {
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
         return .leaf(Headers.Node(
-            property.bytes,
-            forKey: "Content-Length"
+            key: "Content-Length",
+            value: property.bytes
         ))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Content Type/Headers.ContentType.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Content Type/Headers.ContentType.swift
@@ -39,8 +39,8 @@ extension Headers.ContentType {
         property.assertPathway()
         return .leaf(
             Headers.Node(
-                property.contentType.rawValue,
-                forKey: "Content-Type"
+                key: "Content-Type",
+                value: property.contentType.rawValue
             )
         )
     }

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Headers.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Headers.swift
@@ -13,20 +13,12 @@ extension Headers {
     struct Node: PropertyNode {
         let key: String
         let value: Any
-        let next: PropertyNode?
-
-        init(_ value: Any, forKey key: String, next: PropertyNode? = nil) {
-            self.key = key
-            self.value = value
-            self.next = next
-        }
 
         func make(_ make: inout Make) async throws {
             let value = "\(value)"
             if !value.isEmpty {
                 make.request.headers.setValue(value, forKey: key)
             }
-            try await next?.make(&make)
         }
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Host/Headers.Host.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Host/Headers.Host.swift
@@ -53,8 +53,8 @@ extension Headers.Host {
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
         return .leaf(Headers.Node(
-            property.value,
-            forKey: "Host"
+            key: "Host",
+            value: property.value
         ))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Origin/Headers.Origin.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Origin/Headers.Origin.swift
@@ -65,8 +65,8 @@ extension Headers.Origin {
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
         return .leaf(Headers.Node(
-            property.value,
-            forKey: "Origin"
+            key: "Origin",
+            value: property.value
         ))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Referer/Headers.Referer.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Referer/Headers.Referer.swift
@@ -47,8 +47,8 @@ extension Headers.Referer {
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
         return .leaf(Headers.Node(
-            property.value,
-            forKey: "Referer"
+            key: "Referer",
+            value: property.value
         ))
     }
 }

--- a/Tests/RequestDLTests/Properties/Sources/Graph/Resolve/ResolveTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Graph/Resolve/ResolveTests.swift
@@ -113,15 +113,13 @@ extension ResolveTests {
                 LeafNode<Node> {
                     property = Node {
                         key = Accept,
-                        value = application/json,
-                        next = nil
+                        value = application/json
                     }
                 },
                 LeafNode<Node> {
                     property = Node {
                         key = Content-Type,
-                        value = application/json,
-                        next = nil
+                        value = application/json
                     }
                 },
                 LeafNode<Node> {
@@ -195,15 +193,13 @@ extension ResolveTests {
                             LeafNode<Node> {
                                 property = Node {
                                     key = Accept,
-                                    value = application/json,
-                                    next = nil
+                                    value = application/json
                                 }
                             },
                             LeafNode<Node> {
                                 property = Node {
                                     key = Content-Type,
-                                    value = application/json,
-                                    next = nil
+                                    value = application/json
                                 }
                             }
                         ]


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

We changed the `init` of Headers.Node to `init(key:value:)`, which is now automatically generated by the compiler. We also removed the `next` property because it no longer serves any practical purpose.

Fixes **None**

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
