### PR TITLE
Removed async method to make a new client

### DIFF
--- a/Sources/RequestDL/Internals/Sources/Session/Event Loop Manager/Internals.EventLoopGroupManager.swift
+++ b/Sources/RequestDL/Internals/Sources/Session/Event Loop Manager/Internals.EventLoopGroupManager.swift
@@ -16,7 +16,7 @@ extension Internals {
 
         private var groups: [String: EventLoopGroup] = [:]
 
-        private func _makeClient(
+        func client(
             _ configuration: HTTPClient.Configuration,
             for sessionProvider: SessionProvider
         ) -> HTTPClient {
@@ -26,15 +26,6 @@ extension Internals {
                 eventLoopGroupProvider: .shared(group),
                 configuration: configuration
             )
-        }
-
-        nonisolated func client(
-            _ configuration: HTTPClient.Configuration,
-            for sessionProvider: SessionProvider
-        ) async -> HTTPClient {
-            await _Concurrency.Task(priority: .low) {
-                await _makeClient(configuration, for: sessionProvider)
-            }.value
         }
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Graph/Node/Models/PropertyNode.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Node/Models/PropertyNode.swift
@@ -12,7 +12,7 @@ protocol PropertyNode: NodeStringConvertible {
 
 extension PropertyNode {
 
-    nonisolated var nodeDescription: String {
+    var nodeDescription: String {
         #if DEBUG
         return NodeDebug(self).describe()
         #else

--- a/Tests/RequestDLTests/Internals/Sources/Session/Event Loop Manager/InternalsEventLoopManagerTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Session/Event Loop Manager/InternalsEventLoopManagerTests.swift
@@ -55,12 +55,12 @@ class InternalsEventLoopManagerTests: XCTestCase {
         let provider = CustomProvider()
 
         // When
-        let client1 = await manager.client(
+        let client1 = manager.client(
             .init(),
             for: provider
         )
 
-        let client2 = await manager.client(
+        let client2 = manager.client(
             .init(),
             for: provider
         )
@@ -77,7 +77,7 @@ class InternalsEventLoopManagerTests: XCTestCase {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 
         // When
-        let client = await manager.client(
+        let client = manager.client(
             .init(),
             for: .custom(group)
         )


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

After adding RequestActor, EventLoopGroupManager is no longer an actor and therefore, the wrapper method to instantiate HTTPClient is no longer necessary.

Fixes **None**

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] All new and existing tests passed.
