### PR TITLE
Added GraphID

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Any/AnyProperty.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Any/AnyProperty.swift
@@ -13,10 +13,8 @@ public struct AnyProperty: Property {
     /// Initializes a new instance of `AnyProperty` with the given property `Content`.
     public init<Content: Property>(_ property: Content) {
         self.makeProperty = { graph, inputs in
-            let id = ObjectIdentifier(Content.self)
-
-            return try await Content._makeProperty(
-                property: graph.detach(id, next: property),
+            try await Content._makeProperty(
+                property: graph.detach(next: property),
                 inputs: inputs
             )
         }

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Async/AsyncProperty.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Async/AsyncProperty.swift
@@ -54,11 +54,10 @@ extension AsyncProperty {
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
 
-        let id = ObjectIdentifier(Content.self)
         let content = try await property.content()
 
         return try await Content._makeProperty(
-            property: property.detach(id, next: content),
+            property: property.detach(next: content),
             inputs: inputs
         )
     }

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/ForEach/ForEach.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/ForEach/ForEach.swift
@@ -137,7 +137,7 @@ extension ForEach {
             let content = property.content(element)
 
             let output = try await Content._makeProperty(
-                property: property.detach(id, next: content),
+                property: property.detach(id: .custom(id), next: content),
                 inputs: inputs
             )
 

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Modifier/ModifiedProperty.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Modifier/ModifiedProperty.swift
@@ -22,10 +22,8 @@ private struct ModifiedProperty<Content: Property, Modifier: PropertyModifier>: 
         property.assertPathway()
 
         let modifiedContent = _PropertyModifier_Content<Modifier> { graph, inputs in
-            let id = ObjectIdentifier(Content.self)
-
-            return try await Content._makeProperty(
-                property: graph.detach(id, next: property.content),
+            try await Content._makeProperty(
+                property: graph.detach(next: property.content),
                 inputs: inputs
             )
         }
@@ -39,11 +37,10 @@ private struct ModifiedProperty<Content: Property, Modifier: PropertyModifier>: 
 
         operation(&inputs)
 
-        let id = ObjectIdentifier(Modifier.Body.self)
         let content = property.modifier.body(content: modifiedContent)
 
         return try await Modifier.Body._makeProperty(
-            property: property.detach(id, next: content),
+            property: property.detach(next: content),
             inputs: inputs
         )
     }

--- a/Sources/RequestDL/Properties/Sources/Graph/Graph/Models/GraphID.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Graph/Models/GraphID.swift
@@ -1,0 +1,27 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+struct GraphID: Hashable {
+
+    private enum Source: Hashable {
+        case identified(ObjectIdentifier)
+        case constant(Int)
+    }
+
+    private let source: Source
+
+    private init(_ source: Source) {
+        self.source = source
+    }
+
+    static func type<Content>(_ type: Content.Type) -> GraphID {
+        .init(.identified(.init(type)))
+    }
+
+    static func custom<Value: Hashable>(_ value: Value) -> GraphID {
+        .init(.constant(value.hashValue))
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Graph/Graph/Models/IdentifiedGraphValue.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Graph/Models/IdentifiedGraphValue.swift
@@ -6,8 +6,8 @@ import Foundation
 
 protocol IdentifiedGraphValue {
 
-    var id: AnyHashable { get }
-    var nextID: AnyHashable? { get }
+    var id: GraphID { get }
+    var nextID: GraphID? { get }
 
     var previousValue: IdentifiedGraphValue? { get }
 }


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

We refactored _GraphValue to use GraphID and have greater control over the hash that represents the current graph. This will help define the rules for updating DynamicValue. As a result, the graph ID now indirectly refers to the type of object it represents.

This structure may be subject to change in the future if new methods of achieving the same goal are identified, or if new needs arise.

Fixes **None**

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
