### PR TITLE
Added `@StoredObject`

### DIFF
--- a/Sources/RequestDL/Internals/Sources/Storage/Internals.Storage.swift
+++ b/Sources/RequestDL/Internals/Sources/Storage/Internals.Storage.swift
@@ -1,0 +1,68 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+extension Internals {
+
+    @RequestActor
+    class Storage {
+
+        static let lifetime: Int = 5_000_000_000
+        static let shared = Storage(lifetime: lifetime)
+
+        private let lifetime: Int
+        private var table = [AnyHashable: Register]()
+
+        init(lifetime: Int) {
+            self.lifetime = lifetime
+            scheduleCleanup()
+        }
+
+        func setValue<Value>(_ value: Value?, forKey key: AnyHashable) {
+            table[key] = value.map {
+                .init(value: $0)
+            }
+        }
+
+        func getValue<Value>(_ type: Value.Type, forKey key: AnyHashable) -> Value? {
+            guard let value = table[key]?.value as? Value else {
+                return nil
+            }
+
+            table[key] = .init(value: value)
+            return value
+        }
+    }
+}
+
+extension Internals.Storage {
+
+    fileprivate func scheduleCleanup() {
+        _Concurrency.Task(priority: .background) {
+            try await _Concurrency.Task.sleep(nanoseconds: UInt64(lifetime))
+            cleanupIfNeeded()
+            scheduleCleanup()
+        }
+    }
+
+    private func cleanupIfNeeded() {
+        let now = Date()
+        let lifetime = Double(lifetime) / 1_000_000_000
+
+        for (key, value) in table {
+            if now.timeIntervalSince(value.readAt) > lifetime  {
+                table[key] = nil
+            }
+        }
+    }
+}
+
+extension Internals.Storage {
+
+    fileprivate struct Register {
+        let readAt = Date()
+        let value: Any
+    }
+}

--- a/Sources/RequestDL/Internals/Sources/Storage/Internals.Storage.swift
+++ b/Sources/RequestDL/Internals/Sources/Storage/Internals.Storage.swift
@@ -51,10 +51,8 @@ extension Internals.Storage {
         let now = Date()
         let lifetime = Double(lifetime) / 1_000_000_000
 
-        for (key, value) in table {
-            if now.timeIntervalSince(value.readAt) > lifetime  {
-                table[key] = nil
-            }
+        table = table.filter {
+            now.timeIntervalSince($1.readAt) <= lifetime
         }
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Graph/Resolve/Models/Make.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Resolve/Models/Make.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 
+@RequestActor
 struct Make {
 
     var request: Internals.Request

--- a/Sources/RequestDL/Properties/Sources/Graph/Resolve/Models/PropertyInputs.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Resolve/Models/PropertyInputs.swift
@@ -4,15 +4,9 @@
 
 import Foundation
 
+@RequestActor
 public struct _PropertyInputs {
-
     var environment: EnvironmentValues
     var namespaceID: Namespace.ID
-
-    init(
-        environment: EnvironmentValues
-    ) {
-        self.environment = environment
-        self.namespaceID = .global
-    }
+    let seedFactory: SeedFactory
 }

--- a/Sources/RequestDL/Properties/Sources/Graph/Resolve/Models/PropertyOutputs.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Resolve/Models/PropertyOutputs.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 
+@RequestActor
 public struct _PropertyOutputs {
 
     let node: Node
@@ -13,7 +14,6 @@ public struct _PropertyOutputs {
     }
 }
 
-@RequestActor
 extension _PropertyOutputs {
 
     static var empty: Self {

--- a/Sources/RequestDL/Properties/Sources/Graph/Resolve/Resolve.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Resolve/Resolve.swift
@@ -15,7 +15,9 @@ struct Resolve<Root: Property> {
 
     private func inputs() -> _PropertyInputs {
         .init(
-            environment: .init()
+            environment: .init(),
+            namespaceID: .global,
+            seedFactory: .init()
         )
     }
 

--- a/Sources/RequestDL/Properties/Sources/Value/Dynamic Value/DynamicValue.swift
+++ b/Sources/RequestDL/Properties/Sources/Value/Dynamic Value/DynamicValue.swift
@@ -4,4 +4,39 @@
 
 import Foundation
 
+/**
+ This protocol defines a dynamic value used within `Property` objects.
+
+ It is possible to implement a custom `DynamicValue` using the `@propertyWrapper`
+ attribute along with a `@StateObject` attribute inside it.
+
+ Here's an example:
+
+ ```swift
+ @propertyWrapper
+ struct MyWrapper: DynamicValue {
+
+     @StateObject var manager = MyManager()
+
+     var wrappedValue: MyManager {
+         manager
+     }
+ }
+ ```
+
+ In the above example, the `MyWrapper` structure conforms to `DynamicValue` and contains
+ a `@StateObject` variable named `manager`. This allows `MyWrapper` to be used as a
+ property wrapper with a `MyManager` instance as its wrapped value.
+
+ ```swift
+ struct MyProperty: Property {
+
+    @MyWrapper var manager
+
+    var body: some Property {
+        HeaderGroup(manager.headers)
+    }
+ }
+ ```
+*/
 public protocol DynamicValue {}

--- a/Sources/RequestDL/Properties/Sources/Value/Dynamic Value/Model/GraphOperation.swift
+++ b/Sources/RequestDL/Properties/Sources/Value/Dynamic Value/Model/GraphOperation.swift
@@ -42,7 +42,8 @@ extension GraphOperation {
     var operations: [GraphValueOperation] {
         [
             GraphNamespaceOperation(mirror),
-            GraphEnvironmentOperation(mirror)
+            GraphEnvironmentOperation(mirror),
+            GraphStoredObjectOperation(mirror)
         ]
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Value/Dynamic Value/Model/Seed.swift
+++ b/Sources/RequestDL/Properties/Sources/Value/Dynamic Value/Model/Seed.swift
@@ -1,0 +1,26 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+struct Seed: Hashable, CustomStringConvertible {
+
+    private let rawValue: Int
+
+    var description: String {
+        "Seed(\(rawValue))"
+    }
+
+    init(_ rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    static var zero: Seed {
+        .init(.zero)
+    }
+
+    func next() -> Seed {
+        .init(rawValue + 1)
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Value/Dynamic Value/Model/SeedFactory.swift
+++ b/Sources/RequestDL/Properties/Sources/Value/Dynamic Value/Model/SeedFactory.swift
@@ -1,0 +1,27 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+@RequestActor
+struct SeedFactory {
+
+    private let box = Box()
+
+    init() {}
+
+    func callAsFunction(_ id: Namespace.ID) -> Seed {
+        let currentSeed = box.seeds[id] ?? .init(-1)
+        let seed = currentSeed.next()
+        box.seeds[id] = seed
+        return seed
+    }
+}
+
+extension SeedFactory {
+
+    fileprivate class Box {
+        var seeds = [Namespace.ID: Seed]()
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Value/Namespace/Models/GraphNamespaceOperation.swift
+++ b/Sources/RequestDL/Properties/Sources/Value/Namespace/Models/GraphNamespaceOperation.swift
@@ -25,8 +25,7 @@ struct GraphNamespaceOperation<Content>: GraphValueOperation {
             labels.append(child.label ?? "nil")
             let namespaceID = Namespace.ID(
                 base: Content.self,
-                namespace: labels.joined(separator: "."),
-                hashValue: properties.pathway
+                namespace: labels.joined(separator: ".")
             )
 
             namespace.id = namespaceID

--- a/Sources/RequestDL/Properties/Sources/Value/Namespace/Models/Namespace.ID.swift
+++ b/Sources/RequestDL/Properties/Sources/Value/Namespace/Models/Namespace.ID.swift
@@ -6,20 +6,18 @@ import Foundation
 
 extension Namespace {
 
+    /// The ID used for namespace memory storage.
     public struct ID: Hashable {
 
-        private let base: AnyHashable
+        private let base: ObjectIdentifier
         private let namespace: String
-        private let additionalHashValue: AnyHashable
 
         init<Base>(
             base: Base.Type,
-            namespace: String,
-            hashValue: Int
+            namespace: String
         ) {
-            self.base = String(describing: base)
+            self.base = .init(base)
             self.namespace = namespace
-            self.additionalHashValue = hashValue
         }
     }
 }
@@ -31,8 +29,7 @@ extension Namespace.ID {
     static var global: Self {
         .init(
             base: Global.self,
-            namespace: "_global",
-            hashValue: .zero
+            namespace: "_global"
         )
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Value/Namespace/Namespace.swift
+++ b/Sources/RequestDL/Properties/Sources/Value/Namespace/Namespace.swift
@@ -4,14 +4,65 @@
 
 import Foundation
 
+/**
+ The `@Namespace` property wrapper allows you to define a namespace identifier
+ for `Property` objects.
+
+ This creates a namespace ID for storing objects inside the `Property` declaration.
+
+ Here is an example:
+
+ ```swift
+ struct ProjectDefaults: Property {
+
+    @Namespace var projectName
+    @StateObject var pskResolver = PSKResolver()
+
+    var property: some Property {
+        SecureConnection {
+            PSKIdentity(pskResolver)
+        }
+    }
+ }
+ ```
+
+ In this example, the `pskResolver` object will be stored internally and isolated by
+ the `projectName` namespace ID. If you specify multiple namespaces, they will be
+ merged into a single namespace declaration.
+
+ Here is an example where the namespace ID is `_foo._bar`:
+
+ ```swift
+ struct ProjectDefaults: Property {
+
+    @Namespace var foo
+    @Namespace var bar
+
+    @StateObject var pskResolver = PSKResolver()
+
+    var property: some Property {
+        SecureConnection {
+            PSKIdentity(pskResolver)
+        }
+    }
+ }
+ ```
+ */
 @RequestActor
 @propertyWrapper
 public struct Namespace: DynamicValue {
 
     @_Container var id: ID?
 
+    /**
+     Instantiates a namespace identifier for `Property` objects.
+     */
     public init() {}
 
+    /**
+     The identifier for the namespace that automatically is used to store objects inside
+     the `Property` declaration in a isolated memory.
+     */
     public var wrappedValue: ID {
         id ?? .global
     }

--- a/Sources/RequestDL/Properties/Sources/Value/Stored Object/Models/DynamicStoredObject.swift
+++ b/Sources/RequestDL/Properties/Sources/Value/Stored Object/Models/DynamicStoredObject.swift
@@ -1,0 +1,10 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+protocol DynamicStoredObject: DynamicValue {
+
+    func update(_ configuration: StoredObjectConfiguration)
+}

--- a/Sources/RequestDL/Properties/Sources/Value/Stored Object/Models/GraphStoredObjectOperation.swift
+++ b/Sources/RequestDL/Properties/Sources/Value/Stored Object/Models/GraphStoredObjectOperation.swift
@@ -1,0 +1,27 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+struct GraphStoredObjectOperation<Content>: GraphValueOperation {
+
+    private let mirror: DynamicValueMirror<Content>
+
+    init(_ mirror: DynamicValueMirror<Content>) {
+        self.mirror = mirror
+    }
+
+    func callAsFunction(_ properties: inout GraphProperties) {
+        let deepSearch = DynamicValueDeepSearch(mirror)
+
+        for stored in deepSearch(DynamicStoredObject.self) {
+            stored.value.update(.init(
+                namespaceID: properties.inputs.namespaceID,
+                base: Content.self,
+                pathway: properties.pathway,
+                label: stored.label
+            ))
+        }
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Value/Stored Object/Models/GraphStoredObjectOperation.swift
+++ b/Sources/RequestDL/Properties/Sources/Value/Stored Object/Models/GraphStoredObjectOperation.swift
@@ -14,13 +14,14 @@ struct GraphStoredObjectOperation<Content>: GraphValueOperation {
 
     func callAsFunction(_ properties: inout GraphProperties) {
         let deepSearch = DynamicValueDeepSearch(mirror)
+        let id = properties.inputs.namespaceID
 
         for stored in deepSearch(DynamicStoredObject.self) {
             stored.value.update(.init(
-                namespaceID: properties.inputs.namespaceID,
-                base: Content.self,
-                pathway: properties.pathway,
-                label: stored.label
+                id: id,
+                label: stored.label,
+                seed: properties.inputs.seedFactory(id),
+                base: Content.self
             ))
         }
     }

--- a/Sources/RequestDL/Properties/Sources/Value/Stored Object/Models/StoredObjectConfiguration.swift
+++ b/Sources/RequestDL/Properties/Sources/Value/Stored Object/Models/StoredObjectConfiguration.swift
@@ -5,22 +5,23 @@
 import Foundation
 
 struct StoredObjectConfiguration: Hashable {
-    let namespaceID: Namespace.ID
-    let pathway: Int
+
+    let id: Namespace.ID
     let label: String
+    let seed: Seed
 
     private let base: ObjectIdentifier
 
     init<Base>(
-        namespaceID: Namespace.ID,
-        base: Base.Type,
-        pathway: Int,
-        label: String
+        id: Namespace.ID,
+        label: String,
+        seed: Seed,
+        base: Base.Type
     ) {
-        self.namespaceID = namespaceID
-        self.base = .init(base)
-        self.pathway = pathway
+        self.id = id
         self.label = label
+        self.seed = seed
+        self.base = .init(base)
     }
 }
 
@@ -30,10 +31,10 @@ extension StoredObjectConfiguration {
 
     static var global: Self {
         .init(
-            namespaceID: .global,
-            base: Root.self,
-            pathway: .zero,
-            label: "_"
+            id: .global,
+            label: "_",
+            seed: .zero,
+            base: Root.self
         )
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Value/Stored Object/Models/StoredObjectConfiguration.swift
+++ b/Sources/RequestDL/Properties/Sources/Value/Stored Object/Models/StoredObjectConfiguration.swift
@@ -1,0 +1,39 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+struct StoredObjectConfiguration: Hashable {
+    let namespaceID: Namespace.ID
+    let pathway: Int
+    let label: String
+
+    private let base: ObjectIdentifier
+
+    init<Base>(
+        namespaceID: Namespace.ID,
+        base: Base.Type,
+        pathway: Int,
+        label: String
+    ) {
+        self.namespaceID = namespaceID
+        self.base = .init(base)
+        self.pathway = pathway
+        self.label = label
+    }
+}
+
+extension StoredObjectConfiguration {
+
+    private enum Root {}
+
+    static var global: Self {
+        .init(
+            namespaceID: .global,
+            base: Root.self,
+            pathway: .zero,
+            label: "_"
+        )
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Value/Stored Object/StoredObject.swift
+++ b/Sources/RequestDL/Properties/Sources/Value/Stored Object/StoredObject.swift
@@ -1,0 +1,48 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+@propertyWrapper
+public struct StoredObject<Object: AnyObject>: DynamicValue {
+
+    @_Container private var configuration: StoredObjectConfiguration?
+    private let thunk: () -> Object
+
+    public init(wrappedValue thunk: @autoclosure @escaping () -> Object) {
+        self.thunk = thunk
+    }
+
+    public var wrappedValue: Object {
+        let key = Key(configuration: configuration ?? .global)
+
+        if let value = Internals.Storage.shared.getValue(Object.self, forKey: key) {
+            return value
+        }
+
+        let value = thunk()
+        Internals.Storage.shared.setValue(value, forKey: key)
+        return value
+    }
+}
+
+extension StoredObject {
+
+    fileprivate struct Key: Hashable {
+
+        let configuration: StoredObjectConfiguration
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(configuration)
+            hasher.combine(ObjectIdentifier(Object.self))
+        }
+    }
+}
+
+extension StoredObject: DynamicStoredObject {
+
+    func update(_ configuration: StoredObjectConfiguration) {
+        self.configuration = configuration
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Value/Stored Object/StoredObject.swift
+++ b/Sources/RequestDL/Properties/Sources/Value/Stored Object/StoredObject.swift
@@ -4,16 +4,46 @@
 
 import Foundation
 
+/**
+ A property wrapper that defines a stored object inside `Property` objects.
+
+ This wrapper can be used to store any type of object inside the property declaration.
+ The object will be stored in memory.
+
+ Example:
+
+ ```swift
+ struct MyProperty: Property {
+    @StoredObject var myObject = MyClass()
+
+    var body: some Property {
+        ...
+    }
+ }
+ ```
+
+ In this example, an instance of `MyClass` will be stored in the `myObject` property, using
+ the `StoredObject` wrapper. The object will be stored in memory until the conditions of
+ expiring the reference is meet. See `Internal.Storage` for details.
+
+ - Note: The object type must be a class that conforms to `AnyObject` protocol.
+ */
 @propertyWrapper
 public struct StoredObject<Object: AnyObject>: DynamicValue {
 
     @_Container private var configuration: StoredObjectConfiguration?
     private let thunk: () -> Object
 
+    /**
+     Initializes a new `StoredObject` with the given object.
+
+     - Parameter wrappedValue: The object that will be stored in memory.
+     */
     public init(wrappedValue thunk: @autoclosure @escaping () -> Object) {
         self.thunk = thunk
     }
 
+    /// The stored object in memory.
     public var wrappedValue: Object {
         let key = Key(configuration: configuration ?? .global)
 

--- a/Tests/RequestDLTests/Internals/Sources/Storage/InternalsStorageTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Storage/InternalsStorageTests.swift
@@ -1,0 +1,41 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import XCTest
+@testable import RequestDL
+
+@RequestActor
+class InternalsStorageTests: XCTestCase {
+
+    func testStorage_whenSetValue() {
+        // Given
+        let key = "key"
+        let value = 1
+        let storage = Internals.Storage.shared
+
+        // When
+        storage.setValue(value, forKey: key)
+
+        // Then
+        XCTAssertEqual(storage.getValue(Int.self, forKey: key), value)
+    }
+
+    func testStorage_whenExpiredLifetime() async throws {
+        // Given
+        let lifetime = 2_500_000_000
+        let key = "key"
+        let value = 1
+
+        // When
+        let storage = Internals.Storage(lifetime: lifetime)
+        storage.setValue(value, forKey: key)
+
+        // Then
+        XCTAssertNotNil(storage.getValue(Int.self, forKey: key))
+
+        try await _Concurrency.Task.sleep(nanoseconds: UInt64(lifetime * 2))
+
+        XCTAssertNil(storage.getValue(Int.self, forKey: key))
+    }
+}

--- a/Tests/RequestDLTests/Internals/Sources/Storage/InternalsStorageTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Storage/InternalsStorageTests.swift
@@ -8,7 +8,7 @@ import XCTest
 @RequestActor
 class InternalsStorageTests: XCTestCase {
 
-    func testStorage_whenSetValue() {
+    func testStorage_whenSetValue() async throws {
         // Given
         let key = "key"
         let value = 1

--- a/Tests/RequestDLTests/Properties/Sources/Extra Properties/Namespace/NamespaceTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Extra Properties/Namespace/NamespaceTests.swift
@@ -11,7 +11,7 @@ class NamespaceTests: XCTestCase {
 
     struct NamespaceSpy: Property {
 
-        let callback: (Int, Namespace.ID) -> Void
+        let callback: (Namespace.ID) -> Void
 
         var body: Never {
             bodyException()
@@ -22,12 +22,7 @@ class NamespaceTests: XCTestCase {
             property: _GraphValue<NamespaceTests.NamespaceSpy>,
             inputs: _PropertyInputs
         ) async throws -> _PropertyOutputs {
-            let pathway = property._identified.previousValue?.previousValue?.pathway ?? {
-                property.pathway
-            }()
-
-            property.callback(pathway, inputs.namespaceID)
-
+            property.callback(inputs.namespaceID)
             return .empty
         }
     }
@@ -39,7 +34,7 @@ class NamespaceTests: XCTestCase {
         // When
         _ = try await resolve(TestProperty {
             NamespaceSpy {
-                namespaceID = $1
+                namespaceID = $0
             }
         })
 
@@ -69,14 +64,12 @@ extension NamespaceTests {
     func testNamespace_whenSet() async throws {
         // Given
         var namespaceID: Namespace.ID?
-        var hashValue: Int = .zero
 
         // When
         let (_, request) = try await resolve(TestProperty {
             SingleNamespace {
                 NamespaceSpy {
-                    hashValue = $0
-                    namespaceID = $1
+                    namespaceID = $0
                 }
             }
         })
@@ -85,8 +78,7 @@ extension NamespaceTests {
         XCTAssertEqual(request.url, "https://www.apple.com/v1")
         XCTAssertEqual(namespaceID, Namespace.ID(
             base: SingleNamespace<NamespaceSpy>.self,
-            namespace: "_v1",
-            hashValue: hashValue
+            namespace: "_v1"
         ))
     }
 }
@@ -102,7 +94,6 @@ extension NamespaceTests {
 
         init(@PropertyBuilder content: () -> Content) {
             self.content = content()
-            print(self)
         }
 
         var body: some Property {
@@ -114,14 +105,12 @@ extension NamespaceTests {
     func testNamespace_whenSetWithMultiple() async throws {
         // Given
         var namespaceID: Namespace.ID?
-        var hashValue: Int = .zero
 
         // When
         let (_, request) = try await resolve(TestProperty {
             MultipleNamespace {
                 NamespaceSpy {
-                    hashValue = $0
-                    namespaceID = $1
+                    namespaceID = $0
                 }
             }
         })
@@ -130,8 +119,7 @@ extension NamespaceTests {
         XCTAssertEqual(request.url, "https://www.apple.com/multiple/namespace")
         XCTAssertEqual(namespaceID, Namespace.ID(
             base: MultipleNamespace<NamespaceSpy>.self,
-            namespace: "_multiple._namespace",
-            hashValue: hashValue
+            namespace: "_multiple._namespace"
         ))
     }
 }
@@ -142,7 +130,7 @@ extension NamespaceTests {
 
         @Namespace var namespace
 
-        let callback: (Int, Namespace.ID) -> Void
+        let callback: (Namespace.ID) -> Void
 
         func body(content: Content) -> some Property {
             content
@@ -154,14 +142,12 @@ extension NamespaceTests {
     func testNamespace_whenModifier() async throws {
         // Given
         var namespaceID: Namespace.ID?
-        var hashValue: Int = .zero
 
         // When
         let (_, request) = try await resolve(TestProperty {
             Path("v1")
                 .modifier(NamespaceModifier {
-                    hashValue = $0
-                    namespaceID = $1
+                    namespaceID = $0
                 })
         })
 
@@ -169,8 +155,7 @@ extension NamespaceTests {
         XCTAssertEqual(request.url, "https://www.apple.com/v1/namespace")
         XCTAssertEqual(namespaceID, Namespace.ID(
             base: NamespaceModifier.self,
-            namespace: "_namespace",
-            hashValue: hashValue
+            namespace: "_namespace"
         ))
     }
 }

--- a/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/Index.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/Index.swift
@@ -1,0 +1,17 @@
+//
+//  File.swift
+//  
+//
+//  Created by Brenno on 28/04/23.
+//
+
+import Foundation
+
+class Index {
+
+    let rawValue: Int
+
+    init(_ producer: IndexProducer) {
+        rawValue = producer()
+    }
+}

--- a/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/Index.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/Index.swift
@@ -1,9 +1,6 @@
-//
-//  File.swift
-//  
-//
-//  Created by Brenno on 28/04/23.
-//
+/*
+ See LICENSE for this package's licensing information.
+*/
 
 import Foundation
 

--- a/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/IndexFactory.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/IndexFactory.swift
@@ -1,9 +1,6 @@
-//
-//  File.swift
-//  
-//
-//  Created by Brenno on 28/04/23.
-//
+/*
+ See LICENSE for this package's licensing information.
+*/
 
 import Foundation
 

--- a/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/IndexFactory.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/IndexFactory.swift
@@ -1,0 +1,15 @@
+//
+//  File.swift
+//  
+//
+//  Created by Brenno on 28/04/23.
+//
+
+import Foundation
+
+protocol IndexFactory: AnyObject {
+
+    var rawValue: Int { get }
+
+    init()
+}

--- a/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/IndexProducer.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/IndexProducer.swift
@@ -1,0 +1,19 @@
+//
+//  File.swift
+//  
+//
+//  Created by Brenno on 28/04/23.
+//
+
+import Foundation
+
+class IndexProducer {
+
+    private(set) var index = 0
+
+    func callAsFunction() -> Int {
+        let index = index
+        self.index += 1
+        return index
+    }
+}

--- a/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/IndexProducer.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/IndexProducer.swift
@@ -1,9 +1,6 @@
-//
-//  File.swift
-//  
-//
-//  Created by Brenno on 28/04/23.
-//
+/*
+ See LICENSE for this package's licensing information.
+*/
 
 import Foundation
 

--- a/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.CombinedPath.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.CombinedPath.swift
@@ -1,0 +1,58 @@
+//
+//  File.swift
+//  
+//
+//  Created by Brenno on 28/04/23.
+//
+
+import Foundation
+import RequestDL
+
+extension StoredObjectToolbox {
+
+    struct CombinedPath: Property {
+
+        @CombinedProperty var paths
+
+        var body: some Property {
+            ForEach(paths, id: \.self) {
+                RequestDL.Path($0)
+            }
+        }
+    }
+}
+
+private extension StoredObjectToolbox {
+
+    @propertyWrapper
+    struct CombinedProperty: DynamicValue {
+
+        @OneProperty var one
+        @TwoProperty var two
+
+        var wrappedValue: [String] {
+            [one, two]
+        }
+    }
+
+    @propertyWrapper
+    struct OneProperty: DynamicValue {
+
+        @StoredObject var factory = Factory()
+
+        var wrappedValue: String {
+            "\(factory.rawValue)"
+        }
+    }
+
+    @propertyWrapper
+    struct TwoProperty: DynamicValue {
+
+        @StoredObject var factory1 = Factory()
+        @StoredObject var factory2 = Factory()
+
+        var wrappedValue: String {
+            "\(factory1.rawValue).\(factory2.rawValue)"
+        }
+    }
+}

--- a/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.CombinedPath.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.CombinedPath.swift
@@ -1,9 +1,6 @@
-//
-//  File.swift
-//  
-//
-//  Created by Brenno on 28/04/23.
-//
+/*
+ See LICENSE for this package's licensing information.
+*/
 
 import Foundation
 import RequestDL

--- a/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.MultiplePath.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.MultiplePath.swift
@@ -1,9 +1,6 @@
-//
-//  File.swift
-//  
-//
-//  Created by Brenno on 28/04/23.
-//
+/*
+ See LICENSE for this package's licensing information.
+*/
 
 import Foundation
 import RequestDL

--- a/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.MultiplePath.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.MultiplePath.swift
@@ -1,0 +1,23 @@
+//
+//  File.swift
+//  
+//
+//  Created by Brenno on 28/04/23.
+//
+
+import Foundation
+import RequestDL
+
+extension StoredObjectToolbox {
+
+    struct MultiplePath: Property {
+
+        @StoredObject var factory1 = Factory()
+        @StoredObject var factory2 = Factory()
+
+        var body: some Property {
+            RequestDL.Path("\(factory1.rawValue)")
+            RequestDL.Path("\(factory2.rawValue)")
+        }
+    }
+}

--- a/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.OneNamespaceModifier.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.OneNamespaceModifier.swift
@@ -1,9 +1,6 @@
-//
-//  File.swift
-//  
-//
-//  Created by Brenno on 28/04/23.
-//
+/*
+ See LICENSE for this package's licensing information.
+*/
 
 import Foundation
 import RequestDL

--- a/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.OneNamespaceModifier.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.OneNamespaceModifier.swift
@@ -1,0 +1,21 @@
+//
+//  File.swift
+//  
+//
+//  Created by Brenno on 28/04/23.
+//
+
+import Foundation
+import RequestDL
+
+extension StoredObjectToolbox {
+
+    struct OneNamespaceModifier: PropertyModifier {
+
+        @Namespace var one
+
+        func body(content: Content) -> some Property {
+            content
+        }
+    }
+}

--- a/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.Path.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.Path.swift
@@ -1,9 +1,6 @@
-//
-//  File.swift
-//  
-//
-//  Created by Brenno on 28/04/23.
-//
+/*
+ See LICENSE for this package's licensing information.
+*/
 
 import Foundation
 import RequestDL

--- a/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.Path.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.Path.swift
@@ -1,0 +1,21 @@
+//
+//  File.swift
+//  
+//
+//  Created by Brenno on 28/04/23.
+//
+
+import Foundation
+import RequestDL
+
+extension StoredObjectToolbox {
+
+    struct Path: Property {
+
+        @StoredObject var factory = Factory()
+
+        var body: some Property {
+            RequestDL.Path("\(factory.rawValue)")
+        }
+    }
+}

--- a/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.Query.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.Query.swift
@@ -1,0 +1,21 @@
+//
+//  File.swift
+//  
+//
+//  Created by Brenno on 28/04/23.
+//
+
+import Foundation
+import RequestDL
+
+extension StoredObjectToolbox {
+
+    struct Query: Property {
+
+        @StoredObject var factory = Factory()
+
+        var body: some Property {
+            RequestDL.Query(factory.rawValue, forKey: "index")
+        }
+    }
+}

--- a/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.Query.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.Query.swift
@@ -1,9 +1,6 @@
-//
-//  File.swift
-//  
-//
-//  Created by Brenno on 28/04/23.
-//
+/*
+ See LICENSE for this package's licensing information.
+*/
 
 import Foundation
 import RequestDL

--- a/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.TwoNamespaceModifier.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.TwoNamespaceModifier.swift
@@ -1,0 +1,21 @@
+//
+//  File.swift
+//  
+//
+//  Created by Brenno on 28/04/23.
+//
+
+import Foundation
+import RequestDL
+
+extension StoredObjectToolbox {
+
+    struct TwoNamespaceModifier: PropertyModifier {
+
+        @Namespace var two
+
+        func body(content: Content) -> some Property {
+            content
+        }
+    }
+}

--- a/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.TwoNamespaceModifier.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.TwoNamespaceModifier.swift
@@ -1,9 +1,6 @@
-//
-//  File.swift
-//  
-//
-//  Created by Brenno on 28/04/23.
-//
+/*
+ See LICENSE for this package's licensing information.
+*/
 
 import Foundation
 import RequestDL

--- a/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.swift
@@ -1,0 +1,10 @@
+//
+//  File.swift
+//  
+//
+//  Created by Brenno on 28/04/23.
+//
+
+import Foundation
+
+enum StoredObjectToolbox<Factory: IndexFactory> {}

--- a/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/Models/StoredObjectToolbox.swift
@@ -1,9 +1,6 @@
-//
-//  File.swift
-//  
-//
-//  Created by Brenno on 28/04/23.
-//
+/*
+ See LICENSE for this package's licensing information.
+*/
 
 import Foundation
 

--- a/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/StoredObjectTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/StoredObjectTests.swift
@@ -1,0 +1,247 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import XCTest
+@testable import RequestDL
+
+@RequestActor
+class StoredObjectTests: XCTestCase {
+
+    typealias Toolbox = StoredObjectToolbox
+
+    func testStored_whenPath_shouldIndexBeOneAndPathZero() async throws {
+        // Given
+        final class Factory: Index, IndexFactory {
+            static let producer = IndexProducer()
+
+            init() {
+                super.init(Self.producer)
+            }
+        }
+
+        let toolbox = toolbox(Factory.self)
+
+        // When
+        let (_, request1) = try await resolve(TestProperty {
+            toolbox.Path()
+        })
+
+        let (_, request2) = try await resolve(TestProperty {
+            toolbox.Path()
+        })
+
+        // Then
+        XCTAssertEqual(Factory.producer.index, 1)
+        XCTAssertEqual(request1.url, request2.url)
+        XCTAssertEqual(request1.url, "https://www.apple.com/0")
+    }
+
+    func testStored_whenPathDifferentPosition_shouldBeNotEqual() async throws {
+        // Given
+        final class Factory: Index, IndexFactory {
+            static let producer = IndexProducer()
+
+            init() {
+                super.init(Self.producer)
+            }
+        }
+
+        let toolbox = toolbox(Factory.self)
+
+        // When
+        let (_, request1) = try await resolve(TestProperty {
+            BaseURL("www.google.com")
+            toolbox.Path()
+        })
+
+        let (_, request2) = try await resolve(TestProperty {
+            toolbox.Path()
+            BaseURL("www.google.com")
+        })
+
+        // Then
+        XCTAssertEqual(Factory.producer.index, 2)
+        XCTAssertNotEqual(request1.url, request2.url)
+        XCTAssertEqual(request1.url, "https://www.google.com/0")
+        XCTAssertEqual(request2.url, "https://www.google.com/1")
+    }
+
+    func testStored_whenPathWithEqualNamespace() async throws {
+        // Given
+        final class Factory: Index, IndexFactory {
+            static let producer = IndexProducer()
+
+            init() {
+                super.init(Self.producer)
+            }
+        }
+
+        let toolbox = toolbox(Factory.self)
+
+        // When
+        let (_, request1) = try await resolve(TestProperty {
+            toolbox.Path()
+                .modifier(toolbox.OneNamespaceModifier())
+        })
+
+        let (_, request2) = try await resolve(TestProperty {
+            toolbox.Path()
+                .modifier(toolbox.OneNamespaceModifier())
+        })
+
+        // Then
+        XCTAssertEqual(Factory.producer.index, 1)
+        XCTAssertEqual(request1.url, request2.url)
+        XCTAssertEqual(request1.url, "https://www.apple.com/0")
+    }
+
+    func testStored_whenPathWithDifferentNamespace() async throws {
+        // Given
+        final class Factory: Index, IndexFactory {
+            static let producer = IndexProducer()
+
+            init() {
+                super.init(Self.producer)
+            }
+        }
+
+        let toolbox = toolbox(Factory.self)
+
+        // When
+        let (_, request1) = try await resolve(TestProperty {
+            toolbox.Path()
+                .modifier(toolbox.OneNamespaceModifier())
+        })
+
+        let (_, request2) = try await resolve(TestProperty {
+            toolbox.Path()
+                .modifier(toolbox.TwoNamespaceModifier())
+        })
+
+        // Then
+        XCTAssertEqual(Factory.producer.index, 2)
+        XCTAssertEqual(request1.url, "https://www.apple.com/0")
+        XCTAssertEqual(request2.url, "https://www.apple.com/1")
+    }
+
+    func testStored_whenPathQuery_shouldURLContainsZeroAndOnes() async throws {
+        // Given
+        final class Factory: Index, IndexFactory {
+            static let producer = IndexProducer()
+
+            init() {
+                super.init(Self.producer)
+            }
+        }
+
+        let toolbox = toolbox(Factory.self)
+
+        // When
+        let (_, request1) = try await resolve(TestProperty {
+            toolbox.Path()
+            toolbox.Query()
+        })
+
+        let (_, request2) = try await resolve(TestProperty {
+            toolbox.Path()
+            toolbox.Query()
+        })
+
+        // Then
+        XCTAssertEqual(Factory.producer.index, 2)
+        XCTAssertEqual(request1.url, request2.url)
+        XCTAssertEqual(request1.url, "https://www.apple.com/0?index=1")
+    }
+
+    func testStored_whenPathQueryDifferentPosition_shouldBeNotEqual() async throws {
+        // Given
+        final class Factory: Index, IndexFactory {
+            static let producer = IndexProducer()
+
+            init() {
+                super.init(Self.producer)
+            }
+        }
+
+        let toolbox = toolbox(Factory.self)
+
+        // When
+        let (_, request1) = try await resolve(TestProperty {
+            toolbox.Path()
+            toolbox.Query()
+        })
+
+        let (_, request2) = try await resolve(TestProperty {
+            toolbox.Query()
+            toolbox.Path()
+        })
+
+        // Then
+        XCTAssertEqual(Factory.producer.index, 4)
+        XCTAssertNotEqual(request1.url, request2.url)
+        XCTAssertEqual(request1.url, "https://www.apple.com/0?index=1")
+        XCTAssertEqual(request2.url, "https://www.apple.com/3?index=2")
+    }
+
+    func testStored_whenMultiplePath_shouldIndexBeOneAndPathZero() async throws {
+        // Given
+        final class Factory: Index, IndexFactory {
+            static let producer = IndexProducer()
+
+            init() {
+                super.init(Self.producer)
+            }
+        }
+
+        let toolbox = toolbox(Factory.self)
+
+        // When
+        let (_, request1) = try await resolve(TestProperty {
+            toolbox.MultiplePath()
+        })
+
+        let (_, request2) = try await resolve(TestProperty {
+            toolbox.MultiplePath()
+        })
+
+        // Then
+        XCTAssertEqual(Factory.producer.index, 2)
+        XCTAssertEqual(request1.url, request2.url)
+        XCTAssertEqual(request1.url, "https://www.apple.com/0/1")
+    }
+
+    func testStored_whenCombined_shouldRestoreEachOne() async throws {
+        // Given
+        final class Factory: Index, IndexFactory {
+            static let producer = IndexProducer()
+
+            init() {
+                super.init(Self.producer)
+            }
+        }
+
+        let toolbox = toolbox(Factory.self)
+
+        // When
+        let (_, request1) = try await resolve(TestProperty {
+            toolbox.CombinedPath()
+        })
+
+        let (_, request2) = try await resolve(TestProperty {
+            toolbox.CombinedPath()
+        })
+
+        // Then
+        XCTAssertEqual(Factory.producer.index, 3)
+        XCTAssertEqual(request1.url, request2.url)
+        XCTAssertEqual(request1.url, "https://www.apple.com/0/1.2")
+    }
+}
+
+extension StoredObjectTests {
+
+    func toolbox<Factory: IndexFactory>(_ factory: Factory.Type) -> StoredObjectToolbox<Factory>.Type {
+        StoredObjectToolbox<Factory>.self
+    }
+}

--- a/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/StoredObjectTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Value/Stored Object/StoredObjectTests.swift
@@ -61,10 +61,10 @@ class StoredObjectTests: XCTestCase {
         })
 
         // Then
-        XCTAssertEqual(Factory.producer.index, 2)
-        XCTAssertNotEqual(request1.url, request2.url)
+        XCTAssertEqual(Factory.producer.index, 1)
+        XCTAssertEqual(request1.url, request2.url)
         XCTAssertEqual(request1.url, "https://www.google.com/0")
-        XCTAssertEqual(request2.url, "https://www.google.com/1")
+        XCTAssertEqual(request2.url, "https://www.google.com/0")
     }
 
     func testStored_whenPathWithEqualNamespace() async throws {


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

This PR introduces a new property wrapper called `StoredObject` that enables storing any type of object inside the `Property` declaration. The objects will be stored in memory until the reference is no longer needed, as determined by the `Internal.Storage` implementation. 

This wrapper is particularly useful for maintaining references to objects used inside `Property` objects, which allows for equatability checking.

Fixes **None**

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added/updated necessary comments/documentation.
