### PR TITLE
Move configuration of reading mode to request

### DIFF
--- a/Sources/RequestDL/Internals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
+++ b/Sources/RequestDL/Internals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
@@ -16,7 +16,6 @@ extension Internals.Session {
         var proxy: HTTPClient.Configuration.Proxy?
         var ignoreUncleanSSLShutdown: Bool = false
         var decompression: Internals.Decompression = .disabled
-        var readingMode: Internals.Response.ReadingMode = .length(1_024)
         var dnsOverride: [String: String] = [:]
         var networkFrameworkWaitForConnectivity: Bool?
         var httpVersion: Internals.HTTPVersion?

--- a/Sources/RequestDL/Internals/Sources/Session/Session/Internals.Session.swift
+++ b/Sources/RequestDL/Internals/Sources/Session/Session/Internals.Session.swift
@@ -47,7 +47,7 @@ extension Internals {
 
             let upload = DataStream<Int>()
             let head = DataStream<ResponseHead>()
-            let download = DownloadBuffer(readingMode: configuration.readingMode)
+            let download = DownloadBuffer(readingMode: request.readingMode)
 
             let delegate = ClientResponseReceiver(
                 url: request.url,

--- a/Sources/RequestDL/Internals/Sources/Session/Session/Models/Internals.Request.swift
+++ b/Sources/RequestDL/Internals/Sources/Session/Session/Models/Internals.Request.swift
@@ -13,12 +13,14 @@ extension Internals {
         var method: String?
         var headers: Headers
         var body: Body?
+        var readingMode: Internals.Response.ReadingMode
 
         init(url: String) {
             self.url = url
             self.method = nil
             self.headers = .init()
             self.body = nil
+            self.readingMode = .length(1_024)
         }
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Reading Mode/ReadingMode.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Reading Mode/ReadingMode.swift
@@ -49,7 +49,7 @@ extension ReadingMode {
         let mode: Internals.Response.ReadingMode
 
         func make(_ make: inout Make) async throws {
-            make.configuration.readingMode = mode
+            make.request.readingMode = mode
         }
     }
 

--- a/Tests/RequestDLTests/Internals/Sources/Session/Session Configuration/InternalsSessionConfigurationTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Session/Session Configuration/InternalsSessionConfigurationTests.swift
@@ -116,17 +116,6 @@ class InternalsSessionConfigurationTests: XCTestCase {
         )
     }
 
-    func testConfiguration_whenSetReadingMode_shouldBeEqual() async throws {
-        // Given
-        let readingMode = Internals.Response.ReadingMode.separator([70])
-
-        // When
-        configuration.readingMode = readingMode
-
-        // Then
-        XCTAssertEqual(configuration.readingMode, readingMode)
-    }
-
     func testConfiguration_whenSetHttpVersion_shouldBeEqual() async throws {
         // Given
         let version = Internals.HTTPVersion.http1Only
@@ -172,6 +161,5 @@ class InternalsSessionConfigurationTests: XCTestCase {
         )
         XCTAssertEqual(configuration.httpVersion, .automatic)
         XCTAssertTrue(configuration.networkFrameworkWaitForConnectivity)
-        XCTAssertEqual(self.configuration.readingMode, .length(1_024))
     }
 }

--- a/Tests/RequestDLTests/Internals/Sources/Session/Session/Models/InternalsRequestTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Session/Session/Models/InternalsRequestTests.swift
@@ -60,4 +60,20 @@ class InternalsRequestTests: XCTestCase {
         XCTAssertEqual(request.headers.getValue(forKey: key1), value1)
         XCTAssertEqual(request.headers.getValue(forKey: key2), value2)
     }
+
+    func testRequest_whenSetReadingMode() async throws {
+        // Given
+        let readingMode = Internals.Response.ReadingMode.separator([70])
+
+        // When
+        request.readingMode = readingMode
+
+        // Then
+        XCTAssertEqual(request.readingMode, readingMode)
+    }
+
+    func testRequest_whenUnsetReadingMode() async throws {
+        // Then
+        XCTAssertEqual(request.readingMode, .length(1_024))
+    }
 }

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Reading Mode/ReadingModeTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Reading Mode/ReadingModeTests.swift
@@ -13,12 +13,12 @@ class ReadingModeTests: XCTestCase {
         let length = 1_024
 
         // When
-        let (session, _) = try await resolve(TestProperty {
+        let (_, request) = try await resolve(TestProperty {
             ReadingMode(length: length)
         })
 
         // Then
-        XCTAssertEqual(session.configuration.readingMode, .length(length))
+        XCTAssertEqual(request.readingMode, .length(length))
     }
 
     func testReadingBySeparator() async throws {
@@ -26,11 +26,11 @@ class ReadingModeTests: XCTestCase {
         let separator = Array(Data("\n".utf8))
 
         // When
-        let (session, _) = try await resolve(TestProperty {
+        let (_, request) = try await resolve(TestProperty {
             ReadingMode(separator: separator)
         })
 
         // Then
-        XCTAssertEqual(session.configuration.readingMode, .separator(separator))
+        XCTAssertEqual(request.readingMode, .separator(separator))
     }
 }

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Session/SessionTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Session/SessionTests.swift
@@ -29,7 +29,6 @@ class SessionTests: XCTestCase {
             String(describing: sut.decompression),
             String(describing: configuration.decompression)
         )
-        XCTAssertEqual(sut.readingMode, configuration.readingMode)
         XCTAssertEqual(sut.connectionPool, configuration.connectionPool)
     }
 


### PR DESCRIPTION
# Pull Request Template

## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

With the Equatable update for the internal Session.Configuration, it was discovered during the review of some methods that the ReadingMode was in the wrong place. If more than one reading mode option was used in different requests, it generated a bug that caused multiple instances of the same HTTPClient. Therefore, this correction was labeled as a bug fix.

Fixes **None**.

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
