### PR TITLE
Refactor URL configuration into baseURL, path, and queries

### DIFF
--- a/Sources/RequestDL/Internals/Extensions/CharacterSet+Methods.swift
+++ b/Sources/RequestDL/Internals/Extensions/CharacterSet+Methods.swift
@@ -1,0 +1,14 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+extension CharacterSet {
+
+    static var urlQueryRFC3986Allowed: CharacterSet {
+        CharacterSet.urlQueryAllowed.subtracting(CharacterSet(
+            charactersIn: ":#[]@!$&'()*+,;="
+        ))
+    }
+}

--- a/Sources/RequestDL/Internals/Extensions/String+Methods.swift
+++ b/Sources/RequestDL/Internals/Extensions/String+Methods.swift
@@ -1,0 +1,12 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+extension String {
+
+    func addingRFC3986PercentEncoding() -> String {
+        addingPercentEncoding(withAllowedCharacters: .urlQueryRFC3986Allowed) ?? self
+    }
+}

--- a/Sources/RequestDL/Internals/Sources/Log/Message/Internals.Log.Message.swift
+++ b/Sources/RequestDL/Internals/Sources/Log/Message/Internals.Log.Message.swift
@@ -83,24 +83,6 @@ extension Internals.Log.Message {
     }
 }
 
-// MARK: - Resolve
-extension Internals.Log.Message {
-
-    static func cantResolveBaseURLFromNodes<Node, Root>(
-        _ node: Node,
-        for root: Root.Type
-    ) -> Internals.Log.Message {
-        Internals.Log.Message(
-            """
-            Failed to find the required BaseURL object in the context.
-            """,
-            parameters: [
-                String(describing: root): node
-            ]
-        )
-    }
-}
-
 // MARK: - Secure Connection
 extension Internals.Log.Message {
 
@@ -281,17 +263,6 @@ extension Internals.Log.Message {
             """
             Unexpected format for host string: Could not extract the \
             host.
-            """,
-            parameters: [
-                String(describing: type(of: url)): url
-            ]
-        )
-    }
-
-    static func failedToResolveURL<URL>(_ url: URL) -> Internals.Log.Message {
-        Internals.Log.Message(
-            """
-            Failed to create URL from absolute string.
             """,
             parameters: [
                 String(describing: type(of: url)): url

--- a/Sources/RequestDL/Internals/Sources/Session/Session/Models/Internals.Query.swift
+++ b/Sources/RequestDL/Internals/Sources/Session/Session/Models/Internals.Query.swift
@@ -1,0 +1,24 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+extension Internals {
+
+    struct Query {
+        let name: String
+        let value: String
+    }
+}
+
+extension [Internals.Query] {
+
+    func joined() -> String {
+        map {
+            let name = $0.name.addingRFC3986PercentEncoding()
+            let value = $0.value.addingRFC3986PercentEncoding()
+            return "\(name)=\(value)"
+        }.joined(separator: "&")
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Graph/Resolve/Resolve.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Resolve/Resolve.swift
@@ -31,16 +31,10 @@ struct Resolve<Root: Property> {
     func build() async throws -> (Internals.Session, Internals.Request) {
         let output = try await outputs()
 
-        guard let baseURLNode = output.node.first(of: BaseURL.Node.self) else {
-            Internals.Log.failure(
-                .cantResolveBaseURLFromNodes(output.node, for: Self.self)
-            )
-        }
-
         let sessionNode = output.node.first(of: Session.Node.self)
 
         var make = Make(
-            request: Internals.Request(url: baseURLNode.baseURL.absoluteString),
+            request: Internals.Request(),
             configuration: sessionNode?.configuration ?? .init()
         )
 

--- a/Sources/RequestDL/Properties/Sources/URL/Path/Path.swift
+++ b/Sources/RequestDL/Properties/Sources/URL/Path/Path.swift
@@ -81,11 +81,11 @@ extension Path {
         let path: String
 
         func make(_ make: inout Make) async throws {
-            guard let url = URL(string: make.request.url), !path.isEmpty else {
+            guard !path.isEmpty else {
                 return
             }
 
-            make.request.url = url.appendingPathComponent(path).absoluteString
+            make.request.pathComponents.append(path)
         }
     }
 

--- a/Sources/RequestDL/Properties/Sources/URL/Query/Query.swift
+++ b/Sources/RequestDL/Properties/Sources/URL/Query/Query.swift
@@ -53,14 +53,10 @@ extension Query {
         fileprivate let value: String
 
         func make(_ make: inout Make) async throws {
-            guard let url = URL(string: make.request.url) else {
-                return
-            }
-
-            make.request.url = url.appendingQueries([.init(
+            make.request.queries.append(.init(
                 name: key,
                 value: value
-            )]).absoluteString
+            ))
         }
     }
 

--- a/Sources/RequestDL/Properties/Sources/URL/URL/BaseURL.swift
+++ b/Sources/RequestDL/Properties/Sources/URL/URL/BaseURL.swift
@@ -116,15 +116,13 @@ extension BaseURL {
 
 extension BaseURL {
 
-    struct Node: PropertyNode {
+    private struct Node: PropertyNode {
 
-        let baseURL: URL
+        let baseURL: String
 
-        fileprivate init(_ baseURL: URL) {
-            self.baseURL = baseURL
+        func make(_ make: inout Make) async throws {
+            make.request.baseURL = baseURL
         }
-
-        func make(_ make: inout Make) async throws {}
     }
 
     /// This method is used internally and should not be called directly.
@@ -134,13 +132,6 @@ extension BaseURL {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
-
-        guard let baseURL = URL(string: property.absoluteString) else {
-            Internals.Log.failure(
-                .failedToResolveURL(property.absoluteString)
-            )
-        }
-
-        return .leaf(Node(baseURL))
+        return .leaf(Node(baseURL: property.absoluteString))
     }
 }

--- a/Tests/RequestDLTests/Internals/Sources/Session/Session/InternalsSessionTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Session/Session/InternalsSessionTests.swift
@@ -26,7 +26,8 @@ class InternalsSessionTests: XCTestCase {
 
     func testSession_whenPerformingGet_shouldBeValid() async throws {
         // Given
-        let request = Internals.Request(url: "https://google.com")
+        var request = Internals.Request()
+        request.baseURL = "https://google.com"
 
         // When
         let task = try await session.request(request)
@@ -46,7 +47,8 @@ class InternalsSessionTests: XCTestCase {
         let length = 1_023
         let data = Data.randomData(length: length)
 
-        var request = Internals.Request(url: "https://google.com")
+        var request = Internals.Request()
+        request.baseURL = "https://google.com"
         request.method = "POST"
         request.body = Internals.Body(buffers: [
             Internals.DataBuffer(data)
@@ -71,7 +73,8 @@ class InternalsSessionTests: XCTestCase {
 
     func testSession_whenPerformingPostEmptyData_shouldBeValid() async throws {
         // Given
-        var request = Internals.Request(url: "https://google.com")
+        var request = Internals.Request()
+        request.baseURL = "https://google.com"
         request.method = "POST"
         request.body = Internals.Body(buffers: [])
 
@@ -114,7 +117,8 @@ class InternalsSessionTests: XCTestCase {
             port: 8888,
             response: message
         ).run { baseURL in
-            var request = Internals.Request(url: "https://\(baseURL)")
+            var request = Internals.Request()
+            request.baseURL = "https://\(baseURL)"
             request.method = "POST"
             request.body = Internals.Body(fragment, buffers: [
                 fileBuffer

--- a/Tests/RequestDLTests/Internals/Sources/Session/Session/Models/InternalsRequestTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Session/Session/Models/InternalsRequestTests.swift
@@ -13,7 +13,7 @@ class InternalsRequestTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
-        request = .init(url: "")
+        request = .init()
     }
 
     override func tearDown() async throws {
@@ -26,7 +26,7 @@ class InternalsRequestTests: XCTestCase {
         let url = "https://google.com"
 
         // When
-        request = .init(url: url)
+        request.baseURL = url
 
         // Then
         XCTAssertEqual(request.url, url)

--- a/Tests/RequestDLTests/Properties/Sources/URL/Query/QueryTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/URL/Query/QueryTests.swift
@@ -43,7 +43,7 @@ class QueryTests: XCTestCase {
             number=123&\
             page=1&\
             api_key=password&\
-            array=%5B9,%20%22nine%22%5D
+            array=%5B9%2C%20%22nine%22%5D
             """
         )
     }

--- a/Tests/RequestDLTests/Properties/Sources/URL/URL/BaseURLTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/URL/URL/BaseURLTests.swift
@@ -149,7 +149,7 @@ class BaseURLTests: XCTestCase {
         })
 
         // Then
-        XCTAssertEqual(request.url, "ftp://apple.com")
+        XCTAssertEqual(request.url, "https://google.com")
     }
 
     func testNeverBody() async throws {

--- a/Tests/RequestDLTests/Utils/TestProperty.swift
+++ b/Tests/RequestDLTests/Utils/TestProperty.swift
@@ -17,7 +17,7 @@ struct TestProperty<Content: Property>: Property {
     }
 
     var body: some Property {
-        content
         BaseURL("www.apple.com")
+        content
     }
 }


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

The current implementation of URL construction was limited to the initial definition of the BaseURL and to Foundation's methods for URL and URLComponents. This PR refactors the way the URL is constructed by separating it into baseURL, paths, and queries. With this change, it is possible to implement new features and make the existing ones more stable.

Fixes **None**

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
