### PR TITLE
Fix Internals.Headers to support multiple values by key

### DIFF
--- a/Tests/RequestDLTests/Internals/Sources/Session/Session/Models/InternalsSessionHeadersTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Session/Session/Models/InternalsSessionHeadersTests.swift
@@ -64,7 +64,7 @@ class InternalsHeadersTests: XCTestCase {
         XCTAssertEqual(headers.getValue(forKey: key), "\(value); \(addValue)")
     }
 
-    func testHeaders_whenSameKeysWithCaseDiference_shouldObtainSameValue() async throws {
+    func testHeaders_whenSameKeysWithCaseDifference_shouldObtainSameValue() async throws {
         // Given
         let key1 = "Content-Type"
         let key2 = "Content-type"
@@ -143,5 +143,35 @@ class InternalsHeadersTests: XCTestCase {
                 return false
             }
         })
+    }
+
+    func testHeaders_whenContainsValue() async throws {
+        // Given
+        let key = "Content-Type"
+        let value = "application/x-www-form-urlencoded; charset=utf-8"
+
+        // When
+        headers.setValue(value, forKey: key)
+
+        // Then
+        XCTAssertTrue(headers.contains("charset=utf-8", forKey: key))
+    }
+
+    func testHeaders_whenInitWithTuples() async throws {
+        // Given
+        let rawHeaders = [
+            ("Content-Type", "application/x-www-form-urlencoded"),
+            ("content-type", "charset=utf-8")
+        ]
+
+        // When
+        let headers = Internals.Headers(rawHeaders)
+
+        // Then
+        XCTAssertEqual(headers.count, 1)
+        XCTAssertEqual(
+            headers.getValue(forKey: "Content-Type"),
+            "application/x-www-form-urlencoded; charset=utf-8"
+        )
     }
 }

--- a/Tests/RequestDLTests/Internals/Sources/Session/Session/Models/InternalsSessionHeadersTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Session/Session/Models/InternalsSessionHeadersTests.swift
@@ -174,4 +174,21 @@ class InternalsHeadersTests: XCTestCase {
             "application/x-www-form-urlencoded; charset=utf-8"
         )
     }
+
+    func testHeaders_whenHashable() async throws {
+        // Given
+        let headers1 = Internals.Headers([
+            ("Content-Type", "application/json")
+        ])
+
+        let headers2 = Internals.Headers([
+            ("Accept", "text/html")
+        ])
+
+        // Given
+        let sut = Set(arrayLiteral: headers1, headers1, headers2)
+
+        // Then
+        XCTAssertEqual(sut, [headers1, headers2])
+    }
 }


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

This pull request introduces internal code changes in Headers to separate items of a header by ";" and enable the discovery of values separately. This change addresses an issue with the way SwiftNIO's HTTPHeaders were internally converted.

Fixes **None**

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
