### PR TITLE
Internals.ByteURL improvements

### DIFF
--- a/Sources/RequestDL/Internals/Sources/Buffers/Data/Internals.DataBuffer.swift
+++ b/Sources/RequestDL/Internals/Sources/Buffers/Data/Internals.DataBuffer.swift
@@ -135,8 +135,9 @@ extension Internals.DataBuffer {
 extension Internals.DataBuffer {
 
     mutating func readData(_ length: Int) -> Data? {
-        precondition(length >= .zero)
-        precondition(readerIndex + length <= writerIndex)
+        guard length >= .zero, readerIndex + length <= writerIndex else {
+            return nil
+        }
 
         do {
             try storage.moveReaderIndex(to: readerIndex)
@@ -149,8 +150,9 @@ extension Internals.DataBuffer {
     }
 
     mutating func readBytes(_ length: Int) -> [UInt8]? {
-        precondition(length >= .zero)
-        precondition(readerIndex + length <= writerIndex)
+        guard length >= .zero, readerIndex + length <= writerIndex else {
+            return nil
+        }
 
         do {
             try storage.moveReaderIndex(to: readerIndex)

--- a/Sources/RequestDL/Internals/Sources/Buffers/Data/Models/Internals.ByteURL.swift
+++ b/Sources/RequestDL/Internals/Sources/Buffers/Data/Models/Internals.ByteURL.swift
@@ -14,6 +14,8 @@ extension Internals {
 
         init() {}
 
+        /// This should only be used to wraps a ByteBuffer that
+        /// will be managed exclusive by ByteURL
         init(_ buffer: NIOCore.ByteBuffer) {
             self.buffer = buffer
             self.writtenBytes = buffer.writerIndex

--- a/Sources/RequestDL/Internals/Sources/Buffers/Data/Models/Internals.ByteURL.swift
+++ b/Sources/RequestDL/Internals/Sources/Buffers/Data/Models/Internals.ByteURL.swift
@@ -7,12 +7,28 @@ import NIOCore
 
 extension Internals {
 
-    class ByteURL {
+    final class ByteURL {
 
         lazy var buffer = NIOCore.ByteBuffer()
         var writtenBytes: Int = .zero
 
         init() {}
+
+        init(_ buffer: NIOCore.ByteBuffer) {
+            self.buffer = buffer
+            self.writtenBytes = buffer.writerIndex
+        }
+    }
+}
+
+extension Internals.ByteURL: Hashable {
+
+    static func == (_ lhs: Internals.ByteURL, _ rhs: Internals.ByteURL) -> Bool {
+        lhs === rhs
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
     }
 }
 

--- a/Sources/RequestDL/Internals/Sources/Buffers/File/Internals.FileBuffer.swift
+++ b/Sources/RequestDL/Internals/Sources/Buffers/File/Internals.FileBuffer.swift
@@ -137,8 +137,9 @@ extension Internals.FileBuffer {
 extension Internals.FileBuffer {
 
     mutating func readData(_ length: Int) -> Data? {
-        precondition(length >= .zero)
-        precondition(readerIndex + length <= writerIndex)
+        guard length >= .zero, readerIndex + length <= writerIndex else {
+            return nil
+        }
 
         do {
             try storage.moveReaderIndex(to: readerIndex)
@@ -151,8 +152,9 @@ extension Internals.FileBuffer {
     }
 
     mutating func readBytes(_ length: Int) -> [UInt8]? {
-        precondition(length >= .zero)
-        precondition(readerIndex + length <= writerIndex)
+        guard length >= .zero, readerIndex + length <= writerIndex else {
+            return nil
+        }
 
         do {
             try storage.moveReaderIndex(to: readerIndex)

--- a/Sources/RequestDL/Internals/Sources/Session/Session/Models/Internals.ClientResponseReceiver.swift
+++ b/Sources/RequestDL/Internals/Sources/Session/Session/Models/Internals.ClientResponseReceiver.swift
@@ -94,7 +94,9 @@ extension Internals {
                 unexpectedStateOrPhase()
             }
 
-            download.append(buffer)
+            download.append(Internals.DataBuffer(
+                Internals.ByteURL(buffer)
+            ))
 
             state = .downloading
             phase = .download

--- a/Tests/RequestDLTests/Internals/Sources/Buffers/Data/InternalsDataBufferTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Buffers/Data/InternalsDataBufferTests.swift
@@ -562,5 +562,31 @@ class InternalsDataBufferTests: XCTestCase {
         // Then
         XCTAssertEqual(dataBuffer.getBytes(), Array(data[64 ..< data.count]))
     }
+
+    func testDataBuffer_whenReadDataOutOfBounds() async throws {
+        // Given
+        var dataBuffer = Internals.DataBuffer(
+            Data.randomData(length: 64)
+        )
+
+        // When
+        let data = dataBuffer.readData(72)
+
+        // Then
+        XCTAssertNil(data)
+    }
+
+    func testDataBuffer_whenReadBytesOutOfBounds() async throws {
+        // Given
+        var dataBuffer = Internals.DataBuffer(
+            Data.randomData(length: 64)
+        )
+
+        // When
+        let bytes = dataBuffer.readBytes(72)
+
+        // Then
+        XCTAssertNil(bytes)
+    }
 }
 // swiftlint:enable type_body_length file_length

--- a/Tests/RequestDLTests/Internals/Sources/Buffers/Data/InternalsDataBufferTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Buffers/Data/InternalsDataBufferTests.swift
@@ -507,6 +507,20 @@ class InternalsDataBufferTests: XCTestCase {
         XCTAssertNil(data)
     }
 
+    func testDataBuffer_whenInitWithByteURLAlreadySetByteBuffer() async throws {
+        // Given
+        let data = Data.randomData(length: 1_024)
+        let byteBuffer = ByteBuffer(data: data)
+        let byteURL = Internals.ByteURL(byteBuffer)
+
+        // When
+        var dataBuffer = Internals.DataBuffer(byteURL)
+
+        // Then
+        XCTAssertEqual(dataBuffer.writerIndex, data.count)
+        XCTAssertEqual(dataBuffer.readData(data.count), data)
+    }
+
     func testDataBuffer_whenGetData() async throws {
         // Given
         let data = Data.randomData(length: 1_024)

--- a/Tests/RequestDLTests/Internals/Sources/Buffers/Data/Models/InternalsByteURLTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Buffers/Data/Models/InternalsByteURLTests.swift
@@ -1,0 +1,67 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import XCTest
+import NIOCore
+@testable import RequestDL
+
+@RequestActor
+class InternalsByteURLTests: XCTestCase {
+
+    func testByteURL_whenInitEmpty() {
+        // Given
+        let url = Internals.ByteURL()
+
+        // Then
+        XCTAssertEqual(url.buffer.writerIndex, .zero)
+        XCTAssertEqual(url.buffer.readerIndex, .zero)
+        XCTAssertEqual(url.writtenBytes, .zero)
+    }
+
+    func testByteURL_whenInitWithBuffer() {
+        // Given
+        let buffer = ByteBuffer(data: .randomData(length: 64))
+
+        // When
+        let url = Internals.ByteURL(buffer)
+
+        // Then
+        XCTAssertEqual(url.buffer.writerIndex, 64)
+        XCTAssertEqual(url.buffer.readerIndex, .zero)
+        XCTAssertEqual(url.writtenBytes, 64)
+    }
+
+    func testByteURL_whenEquals() {
+        // Given
+        let url = Internals.ByteURL()
+
+        // Then
+        XCTAssertEqual(url, url)
+    }
+
+    func testByteURL_whenNotEquals() {
+        // Given
+        let url1 = Internals.ByteURL()
+        let url2 = Internals.ByteURL()
+
+        // Then
+        XCTAssertNotEqual(url1, url2)
+    }
+
+    func testByteURL_whenHashable() {
+        // Given
+        let url1 = Internals.ByteURL()
+        let url2 = Internals.ByteURL()
+
+        // When
+        var sut = Set<Internals.ByteURL>()
+        sut.insert(url1)
+        sut.insert(url2)
+        sut.insert(url1)
+
+        // Then
+        XCTAssertEqual(sut.count, 2)
+        XCTAssertEqual(sut, [url1, url2])
+    }
+}

--- a/Tests/RequestDLTests/Internals/Sources/Buffers/Data/Models/InternalsByteURLTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Buffers/Data/Models/InternalsByteURLTests.swift
@@ -6,7 +6,6 @@ import XCTest
 import NIOCore
 @testable import RequestDL
 
-@RequestActor
 class InternalsByteURLTests: XCTestCase {
 
     func testByteURL_whenInitEmpty() {

--- a/Tests/RequestDLTests/Internals/Sources/Buffers/File/InternalsFileBufferTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Buffers/File/InternalsFileBufferTests.swift
@@ -555,5 +555,31 @@ class InternalsFileBufferTests: XCTestCase {
         // Then
         XCTAssertEqual(fileBuffer.getBytes(), Array(data[64 ..< data.count]))
     }
+
+    func testFileBuffer_whenReadDataOutOfBounds() async throws {
+        // Given
+        var fileBuffer = Internals.FileBuffer(
+            Data.randomData(length: 64)
+        )
+
+        // When
+        let data = fileBuffer.readData(72)
+
+        // Then
+        XCTAssertNil(data)
+    }
+
+    func testFileBuffer_whenReadBytesOutOfBounds() async throws {
+        // Given
+        var fileBuffer = Internals.FileBuffer(
+            Data.randomData(length: 64)
+        )
+
+        // When
+        let bytes = fileBuffer.readBytes(72)
+
+        // Then
+        XCTAssertNil(bytes)
+    }
 }
 // swiftlint:enable type_body_length file_length

--- a/Tests/RequestDLTests/Internals/Sources/Data Stream/Download/InternalsDownloadBufferTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Data Stream/Download/InternalsDownloadBufferTests.swift
@@ -14,7 +14,7 @@ class InternalsDownloadBufferTests: XCTestCase {
         var download = Internals.DownloadBuffer(readingMode: .length(1_024))
 
         // When
-        download.append(.init(data: data))
+        download.append(Internals.DataBuffer(data))
         download.close()
 
         // Then
@@ -30,7 +30,7 @@ class InternalsDownloadBufferTests: XCTestCase {
 
         // When
         download.failed(AnyError())
-        download.append(.init(data: data))
+        download.append(Internals.DataBuffer(data))
         download.close()
 
         var receivedData = Data()
@@ -61,10 +61,10 @@ class InternalsDownloadBufferTests: XCTestCase {
         var download = Internals.DownloadBuffer(readingMode: .length(length))
 
         // When
-        download.append(.init(data: part1))
-        download.append(.init(data: part2))
-        download.append(.init(data: part3))
-        download.append(.init(data: part4))
+        download.append(Internals.DataBuffer(part1))
+        download.append(Internals.DataBuffer(part2))
+        download.append(Internals.DataBuffer(part3))
+        download.append(Internals.DataBuffer(part4))
         download.close()
 
         // Then
@@ -85,8 +85,8 @@ class InternalsDownloadBufferTests: XCTestCase {
         var download = Internals.DownloadBuffer(readingMode: .separator(Array(separator)))
 
         // When
-        download.append(.init(data: line1 + line2))
-        download.append(.init(data: line3))
+        download.append(Internals.DataBuffer(line1 + line2))
+        download.append(Internals.DataBuffer(line3))
         download.close()
 
         // Then
@@ -103,7 +103,7 @@ class InternalsDownloadBufferTests: XCTestCase {
         var download = Internals.DownloadBuffer(readingMode: .separator(Array(separator)))
 
         // When
-        download.append(.init(data: separator))
+        download.append(Internals.DataBuffer(separator))
         download.close()
 
         // Then
@@ -133,7 +133,7 @@ class InternalsDownloadBufferTests: XCTestCase {
         var download = Internals.DownloadBuffer(readingMode: .length(length))
 
         // When
-        download.append(.init(data: data))
+        download.append(Internals.DataBuffer(data))
         download.close()
 
         // Then


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

A new feature has been added to ByteURL, allowing it to be instantiated with a reference to a ByteBuffer. This change enables the direct use of DataBuffer by DownloadBuffer, replacing the previous usage of ByteBuffer. As a result, byte manipulation has become more robust and consistent with the rest of the project, building upon the existing optimizations.

Furthermore, a bug related to the use of buffers with a length greater than their storage capacity has been addressed. Instead of triggering a fatal error, the buffers now gracefully return nil.

Fixes **None**

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
