### PR TITLE
Session improvements

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Graph/Resolve/Models/Make.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Resolve/Models/Make.swift
@@ -7,14 +7,15 @@ import Foundation
 @RequestActor
 struct Make {
 
-    var request: Internals.Request
+    var provider: SessionProvider?
     var configuration: Internals.Session.Configuration
+    var request: Internals.Request
 
     init(
-        request: Internals.Request,
-        configuration: Internals.Session.Configuration
+        configuration: Internals.Session.Configuration,
+        request: Internals.Request
     ) {
-        self.request = request
         self.configuration = configuration
+        self.request = request
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Graph/Resolve/Resolve.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Resolve/Resolve.swift
@@ -31,17 +31,15 @@ struct Resolve<Root: Property> {
     func build() async throws -> (Internals.Session, Internals.Request) {
         let output = try await outputs()
 
-        let sessionNode = output.node.first(of: Session.Node.self)
-
         var make = Make(
-            request: Internals.Request(),
-            configuration: sessionNode?.configuration ?? .init()
+            configuration: .init(),
+            request: .init()
         )
 
         try await output.node._make(&make)
 
         let session = Internals.Session(
-            provider: sessionNode?.provider ?? .shared,
+            provider: make.provider ?? .shared,
             configuration: make.configuration
         )
 

--- a/Tests/RequestDLTests/Properties/Sources/Graph/Resolve/ResolveTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Graph/Resolve/ResolveTests.swift
@@ -134,26 +134,8 @@ extension ResolveTests {
                 },
                 LeafNode<Node> {
                     property = Node {
-                        configuration = Configuration {
-                            secureConnection = nil,
-                            redirectConfiguration = nil,
-                            timeout = Timeout {
-                                connect = nil,
-                                read = nil
-                            },
-                            connectionPool = ConnectionPool {
-                                idleTimeout = TimeAmount {
-                                    nanoseconds = 60000000000
-                                },
-                                concurrentHTTP1ConnectionsPerHostSoftLimit = 8,
-                                retryConnectionEstablishment = true
-                            },
-                            proxy = nil,
-                            ignoreUncleanSSLShutdown = false,
-                            decompression = Decompression.enabled(Limit.ratio(500)),
-                            dnsOverride = [:],
-                            networkFrameworkWaitForConnectivity = nil,
-                            httpVersion = nil
+                        configuration = Optional<(inout Configuration) -> ()> {
+                            some = (Function)
                         },
                         provider = SharedSessionProvider()
                     }

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Session/SessionTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Session/SessionTests.swift
@@ -188,4 +188,21 @@ class SessionTests: XCTestCase {
         // Then
         try await assertNever(property.body)
     }
+
+    func testSession_whenCollidesPrefersLastDeclared() async throws {
+        // Given
+        let property = TestProperty {
+            Session()
+                .decompressionLimit(.size(200))
+            Session()
+                .waitsForConnectivity(true)
+        }
+
+        // When
+        let (session, _) = try await resolve(property)
+
+        // Then
+        XCTAssertEqual(session.configuration.decompression, .enabled(.size(200)))
+        XCTAssertEqual(session.configuration.networkFrameworkWaitForConnectivity, true)
+    }
 }


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

The Session class has been modified to allow the declaration of two or more sessions within a @PropertyBuilder. This was a long-standing issue present since the early versions of the project, which was recently addressed to eliminate a similar problem with BaseURL.

The provided code snippet demonstrates the valid usage and the resulting combination of the declared sessions as if they were one.

```swift
@PropertyBuilder
func defaultSessions() -> some Property {
    Session()
        .disableDecompression()
    Session()
        .waitsForConnectivity(true)
}
```

This update enables greater flexibility in defining multiple sessions within the @PropertyBuilder context, ensuring improved customization and adherence to project requirements.

Fixes **None**

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
