### PR TITLE
Set methods for buffer protocols

### DIFF
--- a/Sources/RequestDL/Internals/Sources/Buffers/BufferProtocol.swift
+++ b/Sources/RequestDL/Internals/Sources/Buffers/BufferProtocol.swift
@@ -56,4 +56,51 @@ extension BufferProtocol {
         var mutableSelf = self
         return mutableSelf.readBytes(mutableSelf.readableBytes)
     }
+
+    func getData(at index: Int, length: Int) -> Data? {
+        var mutableSelf = self
+
+        guard index + length <= mutableSelf.writerIndex else {
+            return nil
+        }
+
+        mutableSelf.moveReaderIndex(to: index)
+        return mutableSelf.readData(length)
+    }
+
+    func getBytes(at index: Int, length: Int) -> [UInt8]? {
+        var mutableSelf = self
+
+        guard index + length <= mutableSelf.writerIndex else {
+            return nil
+        }
+
+        mutableSelf.moveReaderIndex(to: index)
+        return mutableSelf.readBytes(length)
+    }
+}
+
+extension BufferProtocol {
+
+    func setBytes<S: Sequence>(_ bytes: S) where S.Element == UInt8 {
+        var mutableSelf = self
+        mutableSelf.writeBytes(bytes)
+    }
+
+    func setData<Data: DataProtocol>(_ data: Data) {
+        var mutableSelf = self
+        mutableSelf.writeData(data)
+    }
+
+    func setBytes<S: Sequence>(_ bytes: S, at index: Int) where S.Element == UInt8 {
+        var mutableSelf = self
+        mutableSelf.moveWriterIndex(to: index)
+        mutableSelf.writeBytes(bytes)
+    }
+
+    func setData<Data: DataProtocol>(_ data: Data, at index: Int) {
+        var mutableSelf = self
+        mutableSelf.moveWriterIndex(to: index)
+        mutableSelf.writeData(data)
+    }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Session/Session.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Session/Session.swift
@@ -26,7 +26,7 @@ import NIOCore
 @RequestActor
 public struct Session: Property {
 
-    private(set) var configuration:( (inout Internals.Session.Configuration) -> Void)? = nil
+    private(set) var configuration: ((inout Internals.Session.Configuration) -> Void)?
     let provider: SessionProvider
 
     /// Initializes a new Session object.

--- a/Tests/RequestDLTests/Internals/Sources/Buffers/Data/InternalsDataBufferTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Buffers/Data/InternalsDataBufferTests.swift
@@ -548,5 +548,127 @@ class InternalsDataBufferTests: XCTestCase {
         // Then
         XCTAssertEqual(dataBuffer.getBytes(), Array(data[64 ..< data.count]))
     }
+
+    func testDataBuffer_whenGetBytesAtIndexWithLength() async throws {
+        // Given
+        let data = Data.randomData(length: 1_024)
+        var dataBuffer = Internals.DataBuffer(data)
+
+        // When
+        dataBuffer.moveReaderIndex(to: 64)
+
+        // Then
+
+        XCTAssertEqual(
+            dataBuffer.getBytes(at: 32, length: 64),
+            Array(data[32 ..< 96])
+        )
+    }
+
+    func testDataBuffer_whenGetDataAtIndexWithLength() async throws {
+        // Given
+        let data = Data.randomData(length: 1_024)
+        var dataBuffer = Internals.DataBuffer(data)
+
+        // When
+        dataBuffer.moveReaderIndex(to: 64)
+
+        // Then
+
+        XCTAssertEqual(
+            dataBuffer.getData(at: 32, length: 64),
+            data[32 ..< 96]
+        )
+    }
+
+    func testDataBuffer_whenSetDataWhenMovingWriterIndex() async throws {
+        // Given
+        let data = Data.randomData(length: 1_024)
+        var dataBuffer = Internals.DataBuffer(data)
+
+        let writeData = Data.randomData(length: 64)
+
+        // When
+        dataBuffer.moveWriterIndex(to: data.count - 32)
+        dataBuffer.setData(writeData)
+
+        // Then
+        XCTAssertEqual(dataBuffer.writableBytes, writeData.count)
+
+        dataBuffer.moveReaderIndex(to: dataBuffer.writerIndex)
+        dataBuffer.moveWriterIndex(to: dataBuffer.writerIndex + dataBuffer.writableBytes)
+
+        XCTAssertEqual(
+            dataBuffer.readData(writeData.count),
+            writeData
+        )
+    }
+
+    func testDataBuffer_whenSetDataAtWriterIndex() async throws {
+        // Given
+        let data = Data.randomData(length: 1_024)
+        var dataBuffer = Internals.DataBuffer(data)
+
+        let writeData = Data.randomData(length: 64)
+
+        // When
+        dataBuffer.setData(writeData, at: data.count - 32)
+
+        // Then
+        XCTAssertEqual(dataBuffer.writableBytes, writeData.count - 32)
+
+        dataBuffer.moveReaderIndex(to: dataBuffer.writerIndex - 32)
+        dataBuffer.moveWriterIndex(to: dataBuffer.writerIndex + dataBuffer.writableBytes)
+
+        XCTAssertEqual(
+            dataBuffer.readData(writeData.count),
+            writeData
+        )
+    }
+
+    func testDataBuffer_whenSetBytesWhenMovingWriterIndex() async throws {
+        // Given
+        let data = Data.randomData(length: 1_024)
+        var dataBuffer = Internals.DataBuffer(data)
+
+        let writeBytes = Array(Data.randomData(length: 64))
+
+        // When
+        dataBuffer.moveWriterIndex(to: data.count - 32)
+        dataBuffer.setBytes(writeBytes)
+
+        // Then
+        XCTAssertEqual(dataBuffer.writableBytes, writeBytes.count)
+
+        dataBuffer.moveReaderIndex(to: dataBuffer.writerIndex)
+        dataBuffer.moveWriterIndex(to: dataBuffer.writerIndex + dataBuffer.writableBytes)
+
+        XCTAssertEqual(
+            dataBuffer.readBytes(writeBytes.count),
+            writeBytes
+        )
+    }
+
+    func testDataBuffer_whenSetBytesAtWriterIndex() async throws {
+        // Given
+        let data = Data.randomData(length: 1_024)
+        var dataBuffer = Internals.DataBuffer(data)
+
+        let writeBytes = Array(Data.randomData(length: 64))
+
+        // When
+        dataBuffer.setBytes(writeBytes, at: data.count - 32)
+
+        // Then
+        XCTAssertEqual(dataBuffer.writableBytes, writeBytes.count - 32)
+
+        dataBuffer.moveReaderIndex(to: dataBuffer.writerIndex - 32)
+        dataBuffer.moveWriterIndex(to: dataBuffer.writerIndex + dataBuffer.writableBytes)
+
+        XCTAssertEqual(
+            dataBuffer.readBytes(writeBytes.count),
+            writeBytes
+        )
+    }
 }
 // swiftlint:enable type_body_length file_length

--- a/Tests/RequestDLTests/Internals/Sources/Buffers/File/InternalsFileBufferTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Buffers/File/InternalsFileBufferTests.swift
@@ -555,5 +555,127 @@ class InternalsFileBufferTests: XCTestCase {
         // Then
         XCTAssertEqual(fileBuffer.getBytes(), Array(data[64 ..< data.count]))
     }
+
+    func testFileBuffer_whenGetBytesAtIndexWithLength() async throws {
+        // Given
+        let data = Data.randomData(length: 1_024)
+        var fileBuffer = Internals.FileBuffer(data)
+
+        // When
+        fileBuffer.moveReaderIndex(to: 64)
+
+        // Then
+
+        XCTAssertEqual(
+            fileBuffer.getBytes(at: 32, length: 64),
+            Array(data[32 ..< 96])
+        )
+    }
+
+    func testFileBuffer_whenGetDataAtIndexWithLength() async throws {
+        // Given
+        let data = Data.randomData(length: 1_024)
+        var fileBuffer = Internals.FileBuffer(data)
+
+        // When
+        fileBuffer.moveReaderIndex(to: 64)
+
+        // Then
+
+        XCTAssertEqual(
+            fileBuffer.getData(at: 32, length: 64),
+            data[32 ..< 96]
+        )
+    }
+
+    func testFileBuffer_whenSetDataWhenMovingWriterIndex() async throws {
+        // Given
+        let data = Data.randomData(length: 1_024)
+        var fileBuffer = Internals.FileBuffer(data)
+
+        let writeData = Data.randomData(length: 64)
+
+        // When
+        fileBuffer.moveWriterIndex(to: data.count - 32)
+        fileBuffer.setData(writeData)
+
+        // Then
+        XCTAssertEqual(fileBuffer.writableBytes, writeData.count)
+
+        fileBuffer.moveReaderIndex(to: fileBuffer.writerIndex)
+        fileBuffer.moveWriterIndex(to: fileBuffer.writerIndex + fileBuffer.writableBytes)
+
+        XCTAssertEqual(
+            fileBuffer.readData(writeData.count),
+            writeData
+        )
+    }
+
+    func testFileBuffer_whenSetDataAtWriterIndex() async throws {
+        // Given
+        let data = Data.randomData(length: 1_024)
+        var fileBuffer = Internals.FileBuffer(data)
+
+        let writeData = Data.randomData(length: 64)
+
+        // When
+        fileBuffer.setData(writeData, at: data.count - 32)
+
+        // Then
+        XCTAssertEqual(fileBuffer.writableBytes, writeData.count - 32)
+
+        fileBuffer.moveReaderIndex(to: fileBuffer.writerIndex - 32)
+        fileBuffer.moveWriterIndex(to: fileBuffer.writerIndex + fileBuffer.writableBytes)
+
+        XCTAssertEqual(
+            fileBuffer.readData(writeData.count),
+            writeData
+        )
+    }
+
+    func testFileBuffer_whenSetBytesWhenMovingWriterIndex() async throws {
+        // Given
+        let data = Data.randomData(length: 1_024)
+        var fileBuffer = Internals.FileBuffer(data)
+
+        let writeBytes = Array(Data.randomData(length: 64))
+
+        // When
+        fileBuffer.moveWriterIndex(to: data.count - 32)
+        fileBuffer.setBytes(writeBytes)
+
+        // Then
+        XCTAssertEqual(fileBuffer.writableBytes, writeBytes.count)
+
+        fileBuffer.moveReaderIndex(to: fileBuffer.writerIndex)
+        fileBuffer.moveWriterIndex(to: fileBuffer.writerIndex + fileBuffer.writableBytes)
+
+        XCTAssertEqual(
+            fileBuffer.readBytes(writeBytes.count),
+            writeBytes
+        )
+    }
+
+    func testFileBuffer_whenSetBytesAtWriterIndex() async throws {
+        // Given
+        let data = Data.randomData(length: 1_024)
+        var fileBuffer = Internals.FileBuffer(data)
+
+        let writeBytes = Array(Data.randomData(length: 64))
+
+        // When
+        fileBuffer.setBytes(writeBytes, at: data.count - 32)
+
+        // Then
+        XCTAssertEqual(fileBuffer.writableBytes, writeBytes.count - 32)
+
+        fileBuffer.moveReaderIndex(to: fileBuffer.writerIndex - 32)
+        fileBuffer.moveWriterIndex(to: fileBuffer.writerIndex + fileBuffer.writableBytes)
+
+        XCTAssertEqual(
+            fileBuffer.readBytes(writeBytes.count),
+            writeBytes
+        )
+    }
 }
 // swiftlint:enable type_body_length file_length

--- a/Tests/RequestDLTests/Internals/Sources/Session/Session/Models/InternalsSessionHeadersTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Session/Session/Models/InternalsSessionHeadersTests.swift
@@ -186,7 +186,7 @@ class InternalsHeadersTests: XCTestCase {
         ])
 
         // Given
-        let sut = Set(arrayLiteral: headers1, headers1, headers2)
+        let sut = Set([headers1, headers1, headers2])
 
         // Then
         XCTAssertEqual(sut, [headers1, headers2])

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Content Type/HeadersContentTypeTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Content Type/HeadersContentTypeTests.swift
@@ -29,7 +29,10 @@ class HeadersContentTypeTests: XCTestCase {
     func testHeadersFormURLEncodedContentType() async throws {
         let property = TestProperty(Headers.ContentType(.formURLEncoded))
         let (_, request) = try await resolve(property)
-        XCTAssertEqual(request.headers.getValue(forKey: "Content-Type"), "application/x-www-form-urlencoded; charset=utf-8")
+        XCTAssertEqual(
+            request.headers.getValue(forKey: "Content-Type"),
+            "application/x-www-form-urlencoded; charset=utf-8"
+        )
     }
 
     func testHeadersTextContentType() async throws {


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

Methods for set operations have been added to the BufferProtocol, enabling the ability to write data immutably. These newly introduced methods can be utilized internally to create innovative solutions.

By incorporating these set methods, the BufferProtocol gains enhanced functionality, allowing for immutable data writing operations. This addition opens up possibilities for the development of new solutions and expands the range of capabilities within the protocol.

Fixes **None**

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
