### PR TITLE
Added payloadPartLength(_:) to be used during the upload process

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Payloads/Form Data/FormData.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form Data/FormData.swift
@@ -72,7 +72,7 @@ extension FormData {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
-        return .leaf(FormNode {
+        return .leaf(FormNode(inputs.environment.payloadPartLength) {
             PartFormRawValue(property.buffer.getData() ?? Data(), forHeaders: [
                 kContentDisposition: kContentDispositionValue(
                     property.fileName,

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form File/FormFile.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form File/FormFile.swift
@@ -77,7 +77,7 @@ extension FormFile {
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
 
-        return .leaf(FormNode {
+        return .leaf(FormNode(inputs.environment.payloadPartLength) {
             let data = (try? Data(contentsOf: property.url)) ?? Data()
             return PartFormRawValue(data, forHeaders: [
                 kContentDisposition: kContentDispositionValue(

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form Group/FormGroup.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form Group/FormGroup.swift
@@ -45,6 +45,7 @@ extension FormGroup {
 
     private struct Node: PropertyNode {
 
+        let partLength: Int?
         let nodes: [LeafNode<FormNode>]
 
         func make(_ make: inout Make) async throws {
@@ -57,7 +58,7 @@ extension FormGroup {
                 forKey: "Content-Type"
             )
 
-            make.request.body = Internals.Body(buffers: [
+            make.request.body = Internals.Body(partLength, buffers: [
                 Internals.DataBuffer(constructor.body)
             ])
         }
@@ -78,6 +79,9 @@ extension FormGroup {
 
         let nodes = outputs.node.search(for: FormNode.self)
 
-        return .leaf(Node(nodes: nodes))
+        return .leaf(Node(
+            partLength: inputs.environment.payloadPartLength,
+            nodes: nodes
+        ))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form Group/Models/FormNode.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form Group/Models/FormNode.swift
@@ -7,9 +7,11 @@ import Foundation
 @RequestActor
 struct FormNode: PropertyNode {
 
+    let partLength: Int?
     let factory: () -> PartFormRawValue
 
-    init(_ factory: @escaping () -> PartFormRawValue) {
+    init(_ partLength: Int?, _ factory: @escaping () -> PartFormRawValue) {
+        self.partLength = partLength
         self.factory = factory
     }
 
@@ -21,7 +23,7 @@ struct FormNode: PropertyNode {
             forKey: "Content-Type"
         )
 
-        make.request.body = Internals.Body(buffers: [
+        make.request.body = Internals.Body(partLength, buffers: [
             Internals.DataBuffer(constructor.body)
         ])
     }

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form Value/FormValue.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form Value/FormValue.swift
@@ -46,7 +46,7 @@ extension FormValue {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
-        return .leaf(FormNode {
+        return .leaf(FormNode(inputs.environment.payloadPartLength) {
             PartFormRawValue(Data("\(property.value)".utf8), forHeaders: [
                 kContentDisposition: kContentDispositionValue(
                     nil,

--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload Part Length/PayloadPartLength.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload Part Length/PayloadPartLength.swift
@@ -1,0 +1,28 @@
+/*
+ See LICENSE for this package's licensing information.
+*/
+
+import Foundation
+
+private struct PayloadPartLengthKey: EnvironmentKey {
+    static var defaultValue: Int?
+}
+
+extension EnvironmentValues {
+
+    var payloadPartLength: Int? {
+        get { self[PayloadPartLengthKey.self] }
+        set { self[PayloadPartLengthKey.self] = newValue }
+    }
+}
+
+extension Property {
+
+    /// Sets the length of payload parts to be used during the upload process.
+    ///
+    /// - Parameter length: The desired length of each payload part.
+    /// - Returns: A new instance of Property with the payload part length set.
+    public func payloadPartLength(_ length: Int) -> some Property {
+        environment(\.payloadPartLength, length)
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/PayloadNode.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/PayloadNode.swift
@@ -10,6 +10,7 @@ struct PayloadNode: PropertyNode {
     let isURLEncodedCompatible: Bool
     let buffer: () -> BufferProtocol
     let urlEncoder: URLEncoder
+    let partLength: Int?
 
     func make(_ make: inout Make) async throws {
         guard
@@ -17,7 +18,7 @@ struct PayloadNode: PropertyNode {
             isURLEncoded(make.request.headers),
             let data = buffer().getData()
         else {
-            make.request.body = Internals.Body(buffers: [buffer()])
+            make.request.body = Internals.Body(partLength, buffers: [buffer()])
             return
         }
 
@@ -29,7 +30,7 @@ struct PayloadNode: PropertyNode {
         case let value as [Any]:
             try makeArrayURLEncoded(value, in: &make)
         default:
-            make.request.body = Internals.Body(buffers: [buffer()])
+            make.request.body = Internals.Body(partLength, buffers: [buffer()])
         }
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload/Payload.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload/Payload.swift
@@ -129,7 +129,8 @@ extension Payload {
         return .leaf(PayloadNode(
             isURLEncodedCompatible: property.isURLEncodedCompatible,
             buffer: { buffer(provider) },
-            urlEncoder: inputs.environment.urlEncoder
+            urlEncoder: inputs.environment.urlEncoder,
+            partLength: inputs.environment.payloadPartLength
         ))
     }
 }

--- a/Tests/RequestDLTests/Properties/Sources/Payloads/Form Data/FormDataTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Payloads/Form Data/FormDataTests.swift
@@ -145,4 +145,24 @@ class FormDataTests: XCTestCase {
         // Then
         try await assertNever(property.body)
     }
+
+    func testData_whenPartLengthSet() async throws {
+        // Given
+        let length = 1_024
+
+        // When
+        let (_, request) = try await resolve(TestProperty {
+            FormData(
+                Mock(foo: "bar", date: Date()),
+                forKey: "data",
+                fileName: "contents.json"
+            )
+            .payloadPartLength(length)
+        })
+
+        let sut = try await request.body?.buffers()
+
+        // Then
+        XCTAssertEqual(sut?.count, 1)
+    }
 }

--- a/Tests/RequestDLTests/Properties/Sources/Payloads/Form File/FormFileTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Payloads/Form File/FormFileTests.swift
@@ -170,4 +170,30 @@ class FormFileTests: XCTestCase {
         // Then
         try await assertNever(property.body)
     }
+
+    func testFile_whenPartLengthSet() async throws {
+        // Given
+        let length = 1_024
+        let value = "foo"
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bar")
+
+        try Data(value.utf8).write(to: url)
+
+        // When
+        let (_, request) = try await resolve(TestProperty {
+            FormFile(
+                url,
+                forKey: "document",
+                fileName: nil,
+                type: nil
+            )
+            .payloadPartLength(length)
+        })
+
+        let sut = try await request.body?.buffers()
+
+        // Then
+        XCTAssertEqual(sut?.count, 1)
+    }
 }

--- a/Tests/RequestDLTests/Properties/Sources/Payloads/Form Group/FormGroupTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Payloads/Form Group/FormGroupTests.swift
@@ -176,5 +176,24 @@ class FormGroupTests: XCTestCase {
         // Then
         try await assertNever(property.body)
     }
+
+    func testGroup_whenPartLengthSet() async throws {
+        // Given
+        let length = 1_024
+
+        // When
+        let (_, request) = try await resolve(TestProperty {
+            FormGroup {
+                FormValue("foo", forKey: "key1")
+                FormValue("bar", forKey: "key2")
+            }
+            .payloadPartLength(length)
+        })
+
+        let sut = try await request.body?.buffers()
+
+        // Then
+        XCTAssertEqual(sut?.count, 1)
+    }
 }
 // swiftlint:enable function_body_length

--- a/Tests/RequestDLTests/Properties/Sources/Payloads/Payload/PayloadTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Payloads/Payload/PayloadTests.swift
@@ -251,4 +251,20 @@ class PayloadTests: XCTestCase {
         // Then
         try await assertNever(property.body)
     }
+
+    func testPayload_whenPartLengthSet() async throws {
+        // Given
+        let length = 2
+
+        // When
+        let (_, request) = try await resolve(TestProperty {
+            Payload("abc", using: .utf8)
+                .payloadPartLength(length)
+        })
+
+        let sut = try await request.body?.buffers()
+
+        // Then
+        XCTAssertEqual(sut?.count, 2)
+    }
 }


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

The `payloadPartLength` method enables the specification of the desired length for each payload part. By declaring this method and providing an integer value for the `length` parameter, users can fine-tune the size of payload parts according to their specific requirements. 

This enhancement provides greater flexibility and control over the upload process, allowing for optimized performance and efficient handling of large payloads.

Fixes **None**

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added/updated necessary comments/documentation.
