### PR TITLE
Fix a crash when payload data is empty

### DIFF
--- a/Sources/RequestDL/Internals/Sources/Body/Internals.Body.swift
+++ b/Sources/RequestDL/Internals/Sources/Body/Internals.Body.swift
@@ -53,13 +53,17 @@ extension Internals.Body {
         writer: HTTPClient.Body.StreamWriter,
         body: Internals.BodySequence
     ) -> EventLoopFuture<Void> {
+        guard !body.isEmpty else {
+            Internals.Log.failure(.emptyRequestBody())
+        }
+
         let sequence = Internals.StreamWriterSequence(
             writer: writer,
             body: body
         ).makeIterator()
 
         guard let first = sequence.next() else {
-            Internals.Log.failure(.emptyRequestBody())
+            return writer.write(.byteBuffer(.init()))
         }
 
         return first.flatMapWithEventLoop {

--- a/Sources/RequestDL/Internals/Sources/Body/Models/Internals.BodySequence.swift
+++ b/Sources/RequestDL/Internals/Sources/Body/Models/Internals.BodySequence.swift
@@ -14,6 +14,10 @@ extension Internals {
         let fragmentSize: Int
         private let buffers: [BufferProtocol]
 
+        var isEmpty: Bool {
+            buffers.isEmpty
+        }
+
         init(
             buffers: [BufferProtocol],
             size fragment: Int?

--- a/Tests/RequestDLTests/Internals/Extensions/Internals.Body+.swift
+++ b/Tests/RequestDLTests/Internals/Extensions/Internals.Body+.swift
@@ -42,6 +42,8 @@ extension Internals.Body {
             return eventLoop.makeSucceededVoidFuture()
         })).get()
 
+        try await group.shutdownGracefully()
+
         return buffers
     }
 }

--- a/Tests/RequestDLTests/Internals/Sources/Body/InternalsBodyTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Body/InternalsBodyTests.swift
@@ -43,4 +43,22 @@ class InternalsBodyTests: XCTestCase {
             [Data(string.utf8)]
         )
     }
+
+    func testRequestBody_whenDataIsEmpty() async throws {
+        // Given
+        let string = ""
+
+        let body = Internals.Body(buffers: [
+            Internals.DataBuffer(string)
+        ])
+
+        // When
+        let buffers = try await body.buffers()
+
+        // Then
+        XCTAssertEqual(
+            buffers.resolveData(),
+            []
+        )
+    }
 }


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

Fixed an issue that occurred when the payload of the request is an empty Data.

The PR addresses a bug that caused unexpected behavior when a request's payload was an empty Data object. This issue has been resolved, ensuring proper handling and processing of requests with empty payloads. With this fix, the system now handles such scenarios without any adverse effects, providing more reliable and consistent behavior.

Fixes **None**

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
