### PR TITLE
Change usage of any to string

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Headers/Authorization/Authorization.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Authorization/Authorization.swift
@@ -9,16 +9,30 @@ import Foundation
 public struct Authorization: Property {
 
     private let type: TokenType
-    private let token: Any
+    private let token: String
 
-    /// Creates an `Authorization` instance for the given token type and token value.
-    ///
-    /// - Parameters:
-    ///    - type: The type of the authorization token.
-    ///    - token: The value of the authorization token.
-    public init(_ type: TokenType, token: Any) {
+    /**
+     Initializes a new instance of `Authorization` with the specified token type and token.
+
+     - Parameters:
+        - type: The type of token.
+        - token: The token value.
+     */
+    public init<Token: StringProtocol>(_ type: TokenType, token: Token) {
         self.type = type
-        self.token = token
+        self.token = String(token)
+    }
+
+    /**
+     Initializes a new instance of `Authorization` with the specified token type and token.
+
+     - Parameters:
+        - type: The type of token.
+        - token: The token value.
+     */
+    public init<Token: LosslessStringConvertible>(_ type: TokenType, token: Token) {
+        self.type = type
+        self.token = String(token)
     }
 
     /// Creates an `Authorization` instance for basic authentication using the given username and password.
@@ -42,10 +56,24 @@ public struct Authorization: Property {
 
 extension Authorization {
 
+    /// Creates an `Authorization` instance for the given token type and token value.
+    ///
+    /// - Parameters:
+    ///    - type: The type of the authorization token.
+    ///    - token: The value of the authorization token.
+    @available(*, deprecated, message: "Prefers token as String")
+    public init(_ type: TokenType, token: Any) {
+        self.type = type
+        self.token = "\(token)"
+    }
+}
+
+extension Authorization {
+
     private struct Node: PropertyNode {
 
         let type: TokenType
-        let token: Any
+        let token: String
 
         func make(_ make: inout Make) async throws {
             make.request.headers.setValue(

--- a/Sources/RequestDL/Properties/Sources/Headers/Authorization/Authorization.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Authorization/Authorization.swift
@@ -40,12 +40,16 @@ public struct Authorization: Property {
     /// - Parameters:
     ///    - username: The username to be used for authentication.
     ///    - password: The password to be used for authentication.
-    public init(username: String, password: String) {
+    public init<Username: StringProtocol, Password: StringProtocol>(
+        username: Username,
+        password: Password
+    ) {
         self.type = .basic
         self.token = {
-            Data("\(username):\(password)".utf8)
-                .base64EncodedString()
-        }()
+            Data(String(username).utf8)
+            + Data(":".utf8)
+            + Data(String(password).utf8)
+        }().base64EncodedString()
     }
 
     /// Returns an exception since `Never` is a type that can never be constructed.

--- a/Sources/RequestDL/Properties/Sources/Headers/Header Group/HeaderGroup.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Header Group/HeaderGroup.swift
@@ -49,7 +49,10 @@ extension HeaderGroup where Content == ForEach<[String: Any], String, Headers.`A
     public init(_ dictionary: [String: Any]) {
         self.init {
             ForEach(dictionary, id: \.key) {
-                Headers.Any($0.value, forKey: $0.key)
+                Headers.Any(
+                    name: $0.key,
+                    value: "\($0.value)"
+                )
             }
         }
     }

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Any/Headers.Any.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Any/Headers.Any.swift
@@ -11,24 +11,58 @@ extension Headers {
     public struct `Any`: Property {
 
         let key: String
-        let value: Any
+        let value: String
 
         /**
-         Initializes a new instance of `Any` for the given value and key.
+         Initializes a new instance of `Headers.Any` for the given value and name.
 
          - Parameters:
+            - name: The name to reference the header property.
             - value: The value for the header property.
-            - key: The key to reference the header property.
          */
-        public init<S: StringProtocol>(_ value: Any, forKey key: S) {
-            self.key = "\(key)"
-            self.value = value
+        public init<Name: StringProtocol, Value: StringProtocol>(
+            name: Name,
+            value: Value
+        ) {
+            self.key = String(name)
+            self.value = String(value)
+        }
+
+        /**
+         Initializes a new instance of `Headers.Any` for the given value and name.
+
+         - Parameters:
+            - name: The name to reference the header property.
+            - value: The value for the header property.
+         */
+        public init<Name: StringProtocol, Value: LosslessStringConvertible>(
+            name: Name,
+            value: Value
+        ) {
+            self.key = String(name)
+            self.value = String(value)
         }
 
         /// Returns an exception since `Never` is a type that can never be constructed.
         public var body: Never {
             bodyException()
         }
+    }
+}
+
+extension Headers.`Any` {
+
+    /**
+     Initializes a new instance of `Any` for the given value and key.
+
+     - Parameters:
+        - value: The value for the header property.
+        - key: The key to reference the header property.
+     */
+    @available(*, deprecated, message: "Prefers the string init")
+    public init<S: StringProtocol>(_ value: Any, forKey key: S) {
+        self.key = "\(key)"
+        self.value = "\(value)"
     }
 }
 

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Content Length/Headers.ContentLength.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Content Length/Headers.ContentLength.swift
@@ -39,7 +39,7 @@ extension Headers.ContentLength {
         property.assertPathway()
         return .leaf(Headers.Node(
             key: "Content-Length",
-            value: property.bytes
+            value: String(property.bytes)
         ))
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Headers.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Headers.swift
@@ -11,11 +11,12 @@ extension Headers {
 
     @RequestActor
     struct Node: PropertyNode {
+
         let key: String
-        let value: Any
+        let value: String
 
         func make(_ make: inout Make) async throws {
-            let value = "\(value)"
+            let value = value
             if !value.isEmpty {
                 make.request.headers.setValue(value, forKey: key)
             }

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Host/Headers.Host.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Host/Headers.Host.swift
@@ -10,7 +10,7 @@ extension Headers {
     @RequestActor
     public struct Host: Property {
 
-        private let value: Any
+        private let value: String
 
         /**
          Initializes a `Host` property with the given `host` and `port`.
@@ -33,7 +33,7 @@ extension Headers {
             - host: A `StringProtocol` representing the host.
          */
         public init<S: StringProtocol>(_ host: S) {
-            self.value = host
+            self.value = String(host)
         }
 
         /// Returns an exception since `Never` is a type that can never be constructed.

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Origin/Headers.Origin.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Origin/Headers.Origin.swift
@@ -23,7 +23,7 @@ extension Headers {
     @RequestActor
     public struct Origin: Property {
 
-        private let value: Any
+        private let value: String
 
         /**
          Initializes a `Origin` property with the given `host` and `port`.
@@ -45,7 +45,7 @@ extension Headers {
          - Parameter host: A `StringProtocol` representing the host.
          */
         public init<S: StringProtocol>(_ origin: S) {
-            self.value = origin
+            self.value = String(origin)
         }
 
         /// Returns an exception since `Never` is a type that can never be constructed.

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Referer/Headers.Referer.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Referer/Headers.Referer.swift
@@ -18,7 +18,7 @@ extension Headers {
     @RequestActor
     public struct Referer: Property {
 
-        private let value: Any
+        private let value: String
 
         /**
          Initialize the `Referer` header with a URL that specifies the resource from which
@@ -27,7 +27,7 @@ extension Headers {
          - Parameter url: The URL of the resource.
          */
         public init<S: StringProtocol>(_ url: S) {
-            self.value = url
+            self.value = String(url)
         }
 
         /// Returns an exception since `Never` is a type that can never be constructed.

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form Data/FormData.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form Data/FormData.swift
@@ -78,7 +78,7 @@ extension FormData {
                     property.fileName,
                     forKey: property.key
                 ),
-                "Content-Type": property.contentType
+                "Content-Type": "\(property.contentType)"
             ])
         })
     }

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form File/FormFile.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form File/FormFile.swift
@@ -84,7 +84,7 @@ extension FormFile {
                     property.fileName,
                     forKey: property.key
                 ),
-                "Content-Type": property.contentType
+                "Content-Type": "\(property.contentType)"
             ])
         })
     }

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form Group/Models/PartFormRawValue.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form Group/Models/PartFormRawValue.swift
@@ -7,9 +7,9 @@ import Foundation
 struct PartFormRawValue {
 
     let data: Data
-    let headers: [String: Any]
+    let headers: [String: String]
 
-    init(_ data: Data, forHeaders headers: [String: Any]) {
+    init(_ data: Data, forHeaders headers: [String: String]) {
         self.data = data
         self.headers = headers
     }

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form Value/FormValue.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form Value/FormValue.swift
@@ -11,7 +11,51 @@ import Foundation
 public struct FormValue: Property {
 
     let key: String
-    let value: Any
+    let value: String
+
+    /**
+     Creates a new instance of `FormValue` to represent a value with a corresponding key in a form.
+
+     The value parameter is the actual value to be sent, and key is the reference key used to identify
+     the value when the form is submitted.
+
+     - Parameters:
+        - key: The key used to reference the value in the form.
+        - value: The value to be sent.
+     */
+    public init<Key: StringProtocol, Value: StringProtocol>(
+        key: Key,
+        value: Value
+    ) {
+        self.key = String(key)
+        self.value = String(value)
+    }
+
+    /**
+     Creates a new instance of `FormValue` to represent a value with a corresponding key in a form.
+
+     The value parameter is the actual value to be sent, and key is the reference key used to identify
+     the value when the form is submitted.
+
+     - Parameters:
+        - key: The key used to reference the value in the form.
+        - value: The value to be sent.
+     */
+    public init<Key: StringProtocol, Value: LosslessStringConvertible>(
+        key: Key,
+        value: Value
+    ) {
+        self.key = String(key)
+        self.value = String(value)
+    }
+
+    /// Returns an exception since `Never` is a type that can never be constructed.
+    public var body: Never {
+        bodyException()
+    }
+}
+
+extension FormValue {
 
     /**
      Creates a new instance of `FormValue` to represent a value with a corresponding key in a form.
@@ -23,17 +67,15 @@ public struct FormValue: Property {
         - value: The value to be sent.
         - key: The key used to reference the value in the form.
      */
+    @available(*, deprecated, message: "Prefers String init")
     public init(
         _ value: Any,
         forKey key: String
     ) {
-        self.key = key
-        self.value = value
-    }
-
-    /// Returns an exception since `Never` is a type that can never be constructed.
-    public var body: Never {
-        bodyException()
+        self.init(
+            key: key,
+            value: "\(value)"
+        )
     }
 }
 

--- a/Sources/RequestDL/Properties/Sources/URL/Query Group/Models/QueryNode.swift
+++ b/Sources/RequestDL/Properties/Sources/URL/Query Group/Models/QueryNode.swift
@@ -6,19 +6,9 @@ import Foundation
 
 struct QueryNode: PropertyNode {
 
-    private let name: String
-    private let value: Any
-    private let urlEncoder: URLEncoder
-
-    init(
-        name: String,
-        value: Any,
-        urlEncoder: URLEncoder
-    ) {
-        self.name = name
-        self.value = value
-        self.urlEncoder = urlEncoder
-    }
+    let name: String
+    let value: Any
+    let urlEncoder: URLEncoder
 
     func make(_ make: inout Make) async throws {
         let queries = try urlEncoder.encode(value, forKey: name).map {

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Authorization/AuthorizationTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Authorization/AuthorizationTests.swift
@@ -8,7 +8,7 @@ import XCTest
 @RequestActor
 class AuthorizationTests: XCTestCase {
 
-    func testAuthorizationWithTypeAndToken() async throws {
+    func testAuthorizationWithTypeAndStringToken() async throws {
         // Given
         let auth = Authorization(.bearer, token: "myToken")
 
@@ -17,6 +17,17 @@ class AuthorizationTests: XCTestCase {
 
         // Then
         XCTAssertEqual(request.headers.getValue(forKey: "Authorization"), "Bearer myToken")
+    }
+
+    func testAuthorizationWithTypeAndLosslessStringToken() async throws {
+        // Given
+        let auth = Authorization(.bearer, token: 123)
+
+        // When
+        let (_, request) = try await resolve(TestProperty(auth))
+
+        // Then
+        XCTAssertEqual(request.headers.getValue(forKey: "Authorization"), "Bearer 123")
     }
 
     func testAuthorizationWithUsernameAndPassword() async throws {
@@ -35,5 +46,20 @@ class AuthorizationTests: XCTestCase {
 
         // Then
         try await assertNever(property.body)
+    }
+}
+
+@available(*, deprecated)
+extension AuthorizationTests {
+
+    func testAuthorizationWithTypeAndAnyToken() async throws {
+        // Given
+        let auth = Authorization(.bearer, token: "myToken" as Any)
+
+        // When
+        let (_, request) = try await resolve(TestProperty(auth))
+
+        // Then
+        XCTAssertEqual(request.headers.getValue(forKey: "Authorization"), "Bearer myToken")
     }
 }

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Any/HeadersAnyTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Any/HeadersAnyTests.swift
@@ -8,6 +8,52 @@ import XCTest
 @RequestActor
 class HeadersAnyTests: XCTestCase {
 
+    func testAny_whenInitWithStringValue() async throws {
+        // Given
+        let name = "xxx-api-key"
+        let value = "password"
+
+        // When
+        let (_, request) = try await resolve(TestProperty {
+            Headers.Any(
+                name: name,
+                value: value
+            )
+        })
+
+        // Then
+        XCTAssertEqual(request.headers.getValue(forKey: name), value)
+    }
+
+    func testAny_whenInitWithLosslessValue() async throws {
+        // Given
+        let name = "xxx-api-key"
+        let value = 123
+
+        // When
+        let (_, request) = try await resolve(TestProperty {
+            Headers.Any(
+                name: name,
+                value: value
+            )
+        })
+
+        // Then
+        XCTAssertEqual(request.headers.getValue(forKey: name), "\(value)")
+    }
+
+    func testNeverBody() async throws {
+        // Given
+        let property = Headers.Any(name: "key", value: 123)
+
+        // Then
+        try await assertNever(property.body)
+    }
+}
+
+@available(*, deprecated)
+extension HeadersAnyTests {
+
     func testSingleHeaderAny() async throws {
         let property = TestProperty(Headers.Any("password", forKey: "xxx-api-key"))
         let (_, request) = try await resolve(property)
@@ -24,13 +70,5 @@ class HeadersAnyTests: XCTestCase {
 
         XCTAssertEqual(request.headers.getValue(forKey: "Accept"), "text/html")
         XCTAssertEqual(request.headers.getValue(forKey: "Content-Encoding"), "gzip")
-    }
-
-    func testNeverBody() async throws {
-        // Given
-        let property = Headers.Any(123, forKey: "key")
-
-        // Then
-        try await assertNever(property.body)
     }
 }

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Headers/HeadersTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Headers/HeadersTests.swift
@@ -13,7 +13,7 @@ class HeadersTests: XCTestCase {
             Headers.ContentType(.javascript)
             Headers.Accept(.json)
             Headers.Origin("127.0.0.1:8080")
-            Headers.Any("password", forKey: "xxx-api-key")
+            Headers.Any(name: "xxx-api-key", value: "password")
         }
 
         let (_, request) = try await resolve(property)
@@ -29,8 +29,8 @@ class HeadersTests: XCTestCase {
             Headers.ContentType(.javascript)
             Headers.ContentType(.webp)
             Headers.Accept(.jpeg)
-            Headers.Any("password", forKey: "xxx-api-key")
-            Headers.Any("password123", forKey: "xxx-api-key")
+            Headers.Any(name: "xxx-api-key", value: "password")
+            Headers.Any(name: "xxx-api-key", value: "password123")
         }
 
         let (_, request) = try await resolve(property)
@@ -44,11 +44,11 @@ class HeadersTests: XCTestCase {
         let property = TestProperty {
             Headers.ContentType(.javascript)
             Headers.Accept(.jpeg)
-            Headers.Any("password", forKey: "xxx-api-key")
+            Headers.Any(name: "xxx-api-key", value: "password")
 
             HeaderGroup {
                 Headers.ContentType(.webp)
-                Headers.Any("password123", forKey: "xxx-api-key")
+                Headers.Any(name: "xxx-api-key", value: "password123")
             }
         }
 
@@ -65,7 +65,7 @@ class HeadersTests: XCTestCase {
 
             HeaderGroup {
                 Headers.ContentType(.webp)
-                Headers.Any("password", forKey: "xxx-api-key")
+                Headers.Any(name: "xxx-api-key", value: "password")
             }
 
             Headers.Accept(.jpeg)

--- a/Tests/RequestDLTests/Properties/Sources/Payloads/Form Group/Models/MultipartFormConstructorTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Payloads/Form Group/Models/MultipartFormConstructorTests.swift
@@ -44,7 +44,7 @@ class MultipartFormConstructorTests: XCTestCase {
         let value2 = CharacterSet.alphanumerics.description
         let form2 = PartFormRawValue(Data(value2.utf8), forHeaders: [
             "Content-Disposition": "form-data; name=\"document\"; filename=\"document.pdf\"",
-            "Content-Type": ContentType.pdf
+            "Content-Type": "\(ContentType.pdf)"
         ])
 
         // When

--- a/Tests/RequestDLTests/Properties/Sources/Payloads/Form Group/Models/PartFormRawValueTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Payloads/Form Group/Models/PartFormRawValueTests.swift
@@ -12,9 +12,9 @@ class PartFormRawValueTests: XCTestCase {
         // Given
         let data = "Test data".data(using: .utf8) ?? Data()
 
-        let headers: [String: Any] = [
+        let headers: [String: String] = [
             "Content-Type": "text/plain",
-            "Content-Length": 9,
+            "Content-Length": "9",
             "Custom-Header": "custom-value"
         ]
 
@@ -24,9 +24,9 @@ class PartFormRawValueTests: XCTestCase {
         // Then
         XCTAssertEqual(part.data, data)
         XCTAssertEqual(part.headers.count, 3)
-        XCTAssertEqual(part.headers["Content-Type"] as? String, "text/plain")
-        XCTAssertEqual(part.headers["Content-Length"] as? Int, 9)
-        XCTAssertEqual(part.headers["Custom-Header"] as? String, "custom-value")
+        XCTAssertEqual(part.headers["Content-Type"], "text/plain")
+        XCTAssertEqual(part.headers["Content-Length"], "9")
+        XCTAssertEqual(part.headers["Custom-Header"], "custom-value")
     }
 
     func testContentDispositionValue_withFileName() async throws {

--- a/Tests/RequestDLTests/Properties/Sources/Payloads/Form Value/FormValueTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Payloads/Form Value/FormValueTests.swift
@@ -8,6 +8,78 @@ import XCTest
 @RequestActor
 class FormValueTests: XCTestCase {
 
+    func testValue_whenInitWithStringValue() async throws {
+        // Given
+        let key = "title"
+        let value = "value"
+
+        // When
+        let (_, request) = try await resolve(TestProperty {
+            FormValue(key: key, value: value)
+        })
+
+        let contentTypeHeader = request.headers.getValue(forKey: "Content-Type")
+        let boundary = MultipartFormParser.extractBoundary(contentTypeHeader) ?? "nil"
+
+        let multipartForm = try MultipartFormParser(
+            await request.body?.data() ?? Data(),
+            boundary: boundary
+        ).parse()
+
+        // Then
+        XCTAssertEqual(contentTypeHeader, "multipart/form-data; boundary=\"\(boundary)\"")
+        XCTAssertEqual(multipartForm.items.count, 1)
+
+        XCTAssertEqual(
+            multipartForm.items[0].headers["Content-Disposition"],
+            "form-data; name=\"\(key)\""
+        )
+
+        XCTAssertEqual(multipartForm.items[0].contents, Data(value.utf8))
+    }
+
+    func testValue_whenInitWithLosslessValue() async throws {
+        // Given
+        let key = "title"
+        let value = 123
+
+        // When
+        let (_, request) = try await resolve(TestProperty {
+            FormValue(key: key, value: value)
+        })
+
+        let contentTypeHeader = request.headers.getValue(forKey: "Content-Type")
+        let boundary = MultipartFormParser.extractBoundary(contentTypeHeader) ?? "nil"
+
+        let multipartForm = try MultipartFormParser(
+            await request.body?.data() ?? Data(),
+            boundary: boundary
+        ).parse()
+
+        // Then
+        XCTAssertEqual(contentTypeHeader, "multipart/form-data; boundary=\"\(boundary)\"")
+        XCTAssertEqual(multipartForm.items.count, 1)
+
+        XCTAssertEqual(
+            multipartForm.items[0].headers["Content-Disposition"],
+            "form-data; name=\"\(key)\""
+        )
+
+        XCTAssertEqual(multipartForm.items[0].contents, Data("\(value)".utf8))
+    }
+
+    func testNeverBody() async throws {
+        // Given
+        let property = FormValue.init(key: "key", value: "123")
+
+        // Then
+        try await assertNever(property.body)
+    }
+}
+
+@available(*, deprecated)
+extension FormValueTests {
+
     func testSingleForm() async throws {
         // Given
         let key = "title"
@@ -35,13 +107,5 @@ class FormValueTests: XCTestCase {
         )
 
         XCTAssertEqual(multipartForm.items[0].contents, Data(value.utf8))
-    }
-
-    func testNeverBody() async throws {
-        // Given
-        let property = FormValue("123", forKey: "key")
-
-        // Then
-        try await assertNever(property.body)
     }
 }


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

This PR introduces changes to the usage of `Any` in the `Header`, `Authorization`, and `FormValue` components, replacing it with protocol types. The main objective of this update is to prepare for the upcoming 2.2.0 release, which involves conforming to the `Sendable` protocol.

By transitioning from `Any` to protocol types, we improve the codebase's clarity and type safety. This change ensures that the appropriate types are explicitly used in the relevant components, making the code more robust and easier to understand.

Fixes **None**

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added/updated necessary comments/documentation.
