### PR TITLE
Updated Readme to include project versioning strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ the request is completed. It also decodes the response into an instance of
 This is just a simple example of what RequestDL can do. Check out the documentation
 for more information on how to use it.
 
+## Versioning
+
+We follow semantic versioning for this project. The version number is composed of three parts: MAJOR.MINOR.PATCH.
+
+- MAJOR version: Increments when there are incompatible changes and breaking changes. These changes may require updates to existing code and could potentially break backward compatibility.
+
+- MINOR version: Increments when new features or enhancements are added in a backward-compatible manner. It may include improvements, additions, or modifications to existing functionality.
+
+- The PATCH version includes bug fixes, patches, and safe modifications that address issues, bugs, or vulnerabilities without disrupting existing functionality. It may also include new features, but they must be implemented carefully to avoid breaking changes or compatibility issues.
+
+It is recommended to review the release notes for each version to understand the specific changes and updates made in that particular release.
+
 ## Contributing
 
 If you find a bug or have an idea for a new feature, please open an issue or 


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

This PR adds a new section to the README file, titled "Versioning". The purpose of this section is to provide information and guidelines regarding the versioning scheme used in the project. It explains the three-part version number format: MAJOR.MINOR.PATCH.

By adding this "Versioning" section to the README, we aim to provide developers with a clear understanding of how versioning is managed in the project. It ensures that everyone can easily interpret the version numbers, comprehend the significance of each component, and anticipate the types of changes that are expected in each version category.
