### PR TITLE
Removed some inits that are autogenerated by Swift compiler

### DIFF
--- a/Sources/RequestDL/Tasks/Sources/Interceptor/InterceptedTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Interceptor/InterceptedTask.swift
@@ -21,11 +21,6 @@ public struct InterceptedTask<
 
     let task: Content
     let interceptor: Interceptor
-
-    init(_ task: Content, _ interceptor: Interceptor) {
-        self.task = task
-        self.interceptor = interceptor
-    }
 }
 
 extension InterceptedTask {

--- a/Sources/RequestDL/Tasks/Sources/Interceptors/Breakpoint/Interceptors.Breakpoint.swift
+++ b/Sources/RequestDL/Tasks/Sources/Interceptors/Breakpoint/Interceptors.Breakpoint.swift
@@ -26,8 +26,6 @@ extension Interceptors {
      */
     public struct Breakpoint<Element>: TaskInterceptor {
 
-        init() {}
-
         /**
          Called when a result is received.
 

--- a/Sources/RequestDL/Tasks/Sources/Interceptors/Detach/Interceptors.Detach.swift
+++ b/Sources/RequestDL/Tasks/Sources/Interceptors/Detach/Interceptors.Detach.swift
@@ -26,11 +26,7 @@ extension Interceptors {
      */
     public struct Detach<Element>: TaskInterceptor {
 
-        let detachHandler: (Result<Element, Error>) -> Void
-
-        init(detachHandler: @escaping (Result<Element, Error>) -> Void) {
-            self.detachHandler = detachHandler
-        }
+        let closure: (Result<Element, Error>) -> Void
 
         /**
          A function called with the result of the task.
@@ -39,7 +35,7 @@ extension Interceptors {
          or an `Error`.
          */
         public func received(_ result: Result<Element, Error>) {
-            detachHandler(result)
+            closure(result)
         }
     }
 }
@@ -49,13 +45,13 @@ extension Task {
     /**
      Returns a new `InterceptedTask` object that runs the current task on a separate thread.
 
-     - Parameter handler: A closure that is called with the result of the task when it is complete.
+     - Parameter closure: A closure that is called with the result of the task when it is complete.
 
      - Returns: A new `InterceptedTask` object.
      */
     public func detach(
-        _ handler: @escaping (Result<Element, Error>) -> Void
+        _ closure: @escaping (Result<Element, Error>) -> Void
     ) -> InterceptedTask<Interceptors.Detach<Element>, Self> {
-        intercept(Interceptors.Detach(detachHandler: handler))
+        intercept(Interceptors.Detach(closure: closure))
     }
 }

--- a/Sources/RequestDL/Tasks/Sources/Interceptors/Logger/Interceptors.Logger.swift
+++ b/Sources/RequestDL/Tasks/Sources/Interceptors/Logger/Interceptors.Logger.swift
@@ -25,16 +25,8 @@ extension Interceptors {
      */
     public struct Logger<Element>: TaskInterceptor {
 
-        let isLogActive: Bool
+        let isActive: Bool
         let results: (Element) -> [String]
-
-        init(
-            isActive: Bool,
-            results: @escaping (Element) -> [String]
-        ) {
-            isLogActive = isActive
-            self.results = results
-        }
 
         /**
         Called when the task result is received.
@@ -42,7 +34,7 @@ extension Interceptors {
         - Parameter result: The result of the task execution.
         */
         public func received(_ result: Result<Element, Error>) {
-            guard isLogActive else {
+            guard isActive else {
                 return
             }
 

--- a/Sources/RequestDL/Tasks/Sources/Modifier/ModifiedTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifier/ModifiedTask.swift
@@ -18,11 +18,6 @@ public struct ModifiedTask<Modifier: TaskModifier>: Task {
 
     let task: Modifier.Body
     let modifier: Modifier
-
-    init(_ task: Modifier.Body, _ modifier: Modifier) {
-        self.task = task
-        self.modifier = modifier
-    }
 }
 
 extension ModifiedTask {

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Accept Only Status Code/Modifiers.AcceptOnlyStatusCode.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Accept Only Status Code/Modifiers.AcceptOnlyStatusCode.swift
@@ -9,11 +9,7 @@ extension Modifiers {
     /// A modifier that accepts only a specific set of status codes as a successful result.
     public struct AcceptOnlyStatusCode<Content: Task>: TaskModifier where Content.Element: TaskResultPrimitive {
 
-        private let statusCodes: StatusCodeSet
-
-        init(_ statusCodes: StatusCodeSet) {
-            self.statusCodes = statusCodes
-        }
+        let statusCodes: StatusCodeSet
 
         /**
          Modifies a task to accept only the specified status codes.
@@ -48,6 +44,6 @@ extension Task where Element: TaskResultPrimitive {
     public func acceptOnlyStatusCode(
         _ statusCodes: StatusCodeSet
     ) -> ModifiedTask<Modifiers.AcceptOnlyStatusCode<Self>> {
-        modify(Modifiers.AcceptOnlyStatusCode(statusCodes))
+        modify(Modifiers.AcceptOnlyStatusCode(statusCodes: statusCodes))
     }
 }

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Decode/Modifiers.Decode.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Decode/Modifiers.Decode.swift
@@ -27,20 +27,8 @@ extension Modifiers {
 
         let type: Element.Type
         let decoder: JSONDecoder
-        private let data: (Content.Element) -> Data
-        private let output: (Content.Element, Element) -> Output
-
-        fileprivate init(
-            type: Element.Type,
-            decoder: JSONDecoder,
-            data: @escaping (Content.Element) -> Data,
-            output: @escaping (Content.Element, Element) -> Output
-        ) {
-            self.type = type
-            self.decoder = decoder
-            self.data = data
-            self.output = output
-        }
+        fileprivate let data: (Content.Element) -> Data
+        fileprivate let output: (Content.Element, Element) -> Output
 
         /**
          Decodes the data of the specified `Task` instance into an instance of the `Element`

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Extract Payload/Modifiers.ExtractPayload.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Extract Payload/Modifiers.ExtractPayload.swift
@@ -25,8 +25,6 @@ extension Modifiers {
      */
     public struct ExtractPayload<Content: Task, Element>: TaskModifier where Content.Element == TaskResult<Element> {
 
-        init() {}
-
         /**
          Modifies the task to extract only the payload from a task result.
 

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Flat Map Error/Modifiers.FlatMapError.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Flat Map Error/Modifiers.FlatMapError.swift
@@ -17,11 +17,7 @@ extension Modifiers {
      */
     public struct FlatMapError<Content: Task>: TaskModifier {
 
-        let flatMapErrorHandler: (Error) throws -> Void
-
-        init(flatMapErrorHandler: @escaping (Error) throws -> Void) {
-            self.flatMapErrorHandler = flatMapErrorHandler
-        }
+        let transform: (Error) throws -> Void
 
         /**
          Transforms the result of a `Task` to a new element type.
@@ -34,7 +30,7 @@ extension Modifiers {
             do {
                 return try await task.result()
             } catch {
-                try flatMapErrorHandler(error)
+                try transform(error)
                 throw error
             }
         }
@@ -58,16 +54,16 @@ extension Task {
          }
      ```
 
-     - Parameter flatMapErrorHandler: A closure that takes an `Error` parameter and
+     - Parameter transform: A closure that takes an `Error` parameter and
      returns `Void` to be executed when an error occurs.
 
      - Returns: A `ModifiedTask` with the error-handling behavior specified by the
-     `flatMapErrorHandler` closure.
+     `transform` closure.
      */
     public func flatMapError(
-        _ flatMapErrorHandler: @escaping (Error) throws -> Void
+        _ transform: @escaping (Error) throws -> Void
     ) -> ModifiedTask<Modifiers.FlatMapError<Self>> {
-        modify(Modifiers.FlatMapError(flatMapErrorHandler: flatMapErrorHandler))
+        modify(Modifiers.FlatMapError(transform: transform))
     }
 
     /**
@@ -87,19 +83,19 @@ extension Task {
 
      - Parameter type: The type of error to handle.
 
-     - Parameter flatMapErrorHandler: A closure that takes a parameter of the specified error
+     - Parameter transform: A closure that takes a parameter of the specified error
      type and returns `Void` to be executed when an error of that type occurs.
 
      - Returns: A `ModifiedTask` with the error-handling behavior specified by the
-     `flatMapErrorHandler` closure.
+     `transform` closure.
      */
     public func flatMapError<Failure: Error>(
         _ type: Failure.Type,
-        _ flatMapErrorHandler: @escaping (Failure) throws -> Void
+        _ transform: @escaping (Failure) throws -> Void
     ) -> ModifiedTask<Modifiers.FlatMapError<Self>> {
         flatMapError {
             if let error = $0 as? Failure {
-                try flatMapErrorHandler(error)
+                try transform(error)
             }
         }
     }

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Key Path/Models/AbstractKeyPath.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Key Path/Models/AbstractKeyPath.swift
@@ -14,8 +14,6 @@ import Foundation
 @dynamicMemberLookup
 public struct AbstractKeyPath {
 
-    init() {}
-
     /**
      A subscript that allows accessing a member of a AbstractKeyPath instance dynamically.
 

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Key Path/Modifiers.KeyPath.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Key Path/Modifiers.KeyPath.swift
@@ -21,19 +21,9 @@ extension Modifiers {
      */
     public struct KeyPath<Content: Task>: TaskModifier {
 
-        let keyPath: String
-        private let data: (Content.Element) -> Data
-        private let element: (Content.Element, Data) -> Content.Element
-
-        fileprivate init(
-            keyPath: Swift.KeyPath<AbstractKeyPath, String>,
-            data: @escaping (Content.Element) -> Data,
-            element: @escaping (Content.Element, Data) -> Content.Element
-        ) {
-            self.keyPath = AbstractKeyPath()[keyPath: keyPath]
-            self.data = data
-            self.element = element
-        }
+        let keyPath: Swift.KeyPath<AbstractKeyPath, String>
+        fileprivate let data: (Content.Element) -> Data
+        fileprivate let element: (Content.Element, Data) -> Content.Element
 
         /**
          Transforms the result of the task by extracting a sub-value using the given key path.
@@ -51,6 +41,8 @@ extension Modifiers {
                     options: []
                 ) as? [String: Any]
             else { throw KeyPathInvalidDataError() }
+
+            let keyPath = AbstractKeyPath()[keyPath: keyPath]
 
             guard let value = dictionary[keyPath] else {
                 throw KeyPathNotFound(keyPath: keyPath)

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Map Error/Modifiers.MapError.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Map Error/Modifiers.MapError.swift
@@ -10,11 +10,7 @@ extension Modifiers {
     /// error handling and transformation.
     public struct MapError<Content: Task>: TaskModifier {
 
-        let mapErrorHandler: (Error) throws -> Element
-
-        init(mapErrorHandler: @escaping (Error) throws -> Element) {
-            self.mapErrorHandler = mapErrorHandler
-        }
+        let transform: (Error) throws -> Element
 
         /**
          A mapping function that transforms the error of the task result to a new error.
@@ -26,7 +22,7 @@ extension Modifiers {
             do {
                 return try await task.result()
             } catch {
-                return try mapErrorHandler(error)
+                return try transform(error)
             }
         }
     }
@@ -37,13 +33,13 @@ extension Task {
     /**
      Returns a new `Task` with the error of the original `Task` mapped to a new error.
 
-     - Parameter mapErrorHandler: A mapping function that transforms the error of the
+     - Parameter transform: A mapping function that transforms the error of the
      task result to a new error.
      - Returns: A new `Task` with the mapped error.
      */
     public func mapError(
-        _ mapErrorHandler: @escaping (Error) throws -> Element
+        _ transform: @escaping (Error) throws -> Element
     ) -> ModifiedTask<Modifiers.MapError<Self>> {
-        modify(Modifiers.MapError(mapErrorHandler: mapErrorHandler))
+        modify(Modifiers.MapError(transform: transform))
     }
 }

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Map/Modifiers.Map.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Map/Modifiers.Map.swift
@@ -27,11 +27,8 @@ extension Modifiers {
      */
     public struct Map<Content: Task, NewElement>: TaskModifier {
 
-        let mapHandler: (Content.Element) throws -> NewElement
+        let transform: (Content.Element) throws -> NewElement
 
-        init(mapHandler: @escaping (Content.Element) throws -> NewElement) {
-            self.mapHandler = mapHandler
-        }
         /**
          Transforms the element of the given `Task` using the provided closure.
 
@@ -40,7 +37,7 @@ extension Modifiers {
          - Throws: The error thrown by the closure, if any.
          */
         public func task(_ task: Content) async throws -> NewElement {
-            try mapHandler(await task.result())
+            try transform(await task.result())
         }
     }
 }
@@ -50,12 +47,12 @@ extension Task {
     /**
      Transforms the element of the `Task` using the provided closure.
 
-     - Parameter mapHandler: The closure that transforms the original element.
+     - Parameter transform: The closure that transforms the original element.
      - Returns: A modified `Task` with the transformed element.
      */
     public func map<NewElement>(
-        _ mapHandler: @escaping (Element) throws -> NewElement
+        _ transform: @escaping (Element) throws -> NewElement
     ) -> ModifiedTask<Modifiers.Map<Self, NewElement>> {
-        modify(Modifiers.Map(mapHandler: mapHandler))
+        modify(Modifiers.Map(transform: transform))
     }
 }

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/On Status Code/Modifiers.OnStatusCode.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/On Status Code/Modifiers.OnStatusCode.swift
@@ -19,16 +19,8 @@ extension Modifiers {
      */
     public struct OnStatusCode<Content: Task>: TaskModifier where Content.Element: TaskResultPrimitive {
 
-        private let contains: (StatusCode) -> Bool
-        private let mapHandler: (Content.Element) throws -> Void
-
-        init(
-            contains: @escaping (StatusCode) -> Bool,
-            map: @escaping (Content.Element) throws -> Void
-        ) {
-            self.contains = contains
-            self.mapHandler = map
-        }
+        let contains: (StatusCode) -> Bool
+        let transform: (Content.Element) throws -> Void
 
         /**
          A function that modifies the task and returns the result.
@@ -43,7 +35,7 @@ extension Modifiers {
                 return result
             }
 
-            try mapHandler(result)
+            try transform(result)
             return result
         }
     }
@@ -52,12 +44,12 @@ extension Modifiers {
 extension Task where Element: TaskResultPrimitive {
 
     private func onStatusCode(
-        _ map: @escaping (Element) throws -> Void,
+        _ transform: @escaping (Element) throws -> Void,
         contains: @escaping (StatusCode) -> Bool
     ) -> ModifiedTask<Modifiers.OnStatusCode<Self>> {
         modify(.init(
             contains: contains,
-            map: map
+            transform: transform
         ))
     }
 
@@ -67,16 +59,16 @@ extension Task where Element: TaskResultPrimitive {
 
      - Parameters:
         - statusCode: The range of status codes that satisfy the specified condition.
-        - mapHandler: The closure to be executed when the HTTP status code of the
+        - transform: The closure to be executed when the HTTP status code of the
      response satisfies the specified condition.
 
      - Returns: The modified task with the `OnStatusCode` modifier applied.
      */
     public func onStatusCode(
         _ statusCode: Range<StatusCode>,
-        _ mapHandler: @escaping (Element) throws -> Void
+        _ transform: @escaping (Element) throws -> Void
     ) -> ModifiedTask<Modifiers.OnStatusCode<Self>> {
-        onStatusCode(mapHandler) {
+        onStatusCode(transform) {
             statusCode.contains($0)
         }
     }
@@ -87,16 +79,16 @@ extension Task where Element: TaskResultPrimitive {
 
      - Parameters:
         - statusCode: The set of status codes that satisfy the specified condition.
-        - mapHandler: The closure to be executed when the HTTP status code of the response
+        - transform: The closure to be executed when the HTTP status code of the response
      satisfies the specified condition.
 
      - Returns: The modified task with the `OnStatusCode` modifier applied.
      */
     public func onStatusCode(
         _ statusCode: StatusCodeSet,
-        _ mapHandler: @escaping (Element) throws -> Void
+        _ transform: @escaping (Element) throws -> Void
     ) -> ModifiedTask<Modifiers.OnStatusCode<Self>> {
-        onStatusCode(mapHandler) {
+        onStatusCode(transform) {
             statusCode.contains($0)
         }
     }
@@ -107,16 +99,16 @@ extension Task where Element: TaskResultPrimitive {
 
      - Parameters:
         - statusCode: The status code that satisfies the specified condition.
-        - mapHandler: The closure to be executed when the HTTP status code of the response
+        - transform: The closure to be executed when the HTTP status code of the response
      satisfies the specified condition.
 
      - Returns: The modified task with the `OnStatusCode` modifier applied.
      */
     public func onStatusCode(
         _ statusCode: StatusCode,
-        _ mapHandler: @escaping (Element) throws -> Void
+        _ transform: @escaping (Element) throws -> Void
     ) -> ModifiedTask<Modifiers.OnStatusCode<Self>> {
-        onStatusCode(mapHandler) {
+        onStatusCode(transform) {
             statusCode == $0
         }
     }

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/RawTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/RawTask.swift
@@ -6,11 +6,7 @@ import Foundation
 
 struct RawTask<Content: Property>: Task {
 
-    private let content: Content
-
-    init(content: Content) {
-        self.content = content
-    }
+    let content: Content
 }
 
 extension RawTask {

--- a/Sources/RequestDL/Tasks/Sources/Task.swift
+++ b/Sources/RequestDL/Tasks/Sources/Task.swift
@@ -46,7 +46,7 @@ extension Task {
     public func intercept<Interceptor: TaskInterceptor>(
         _ interceptor: Interceptor
     ) -> InterceptedTask<Interceptor, Self> {
-        InterceptedTask(self, interceptor)
+        InterceptedTask(task: self, interceptor: interceptor)
     }
 
     /**
@@ -61,6 +61,6 @@ extension Task {
     public func modify<Modifier: TaskModifier>(
         _ modifier: Modifier
     ) -> ModifiedTask<Modifier> where Modifier.Body == Self {
-        ModifiedTask(self, modifier)
+        ModifiedTask(task: self, modifier: modifier)
     }
 }


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

This PR removes several initializers that are automatically generated by the Swift compiler.

During the code review process, it was identified that these auto-generated initializers are unnecessary and redundant, as they provide the same functionality as the default initializers provided by Swift. By removing these auto-generated initializers, we simplify the codebase and eliminate any confusion or redundancy caused by their presence.

This action helps improve the overall code quality and maintainability of the project. It ensures that only necessary and intentional initializers are included, reducing clutter and potential confusion for developers working with the codebase.

Please note that no changes were made to the functionality or behavior of the code. This PR solely focuses on removing auto-generated initializers to streamline the codebase.

Fixes **None**

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
