### PR TITLE
ByteURL was causing wrong read operations

### DIFF
--- a/Sources/RequestDL/Internals/Sources/Buffers/Data/Models/Internals.ByteURL.swift
+++ b/Sources/RequestDL/Internals/Sources/Buffers/Data/Models/Internals.ByteURL.swift
@@ -37,8 +37,9 @@ extension Internals {
         /// This should only be used to wraps a ByteBuffer that
         /// will be managed exclusive by ByteURL
         init(_ buffer: NIOCore.ByteBuffer) {
+            let buffer = buffer.slice()
             self._buffer = buffer
-            self._writtenBytes = buffer.writerIndex
+            self._writtenBytes = buffer.readableBytes
         }
     }
 }

--- a/Tests/RequestDLTests/Internals/Sources/Buffers/Data/Models/InternalsByteURLTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Buffers/Data/Models/InternalsByteURLTests.swift
@@ -31,6 +31,21 @@ class InternalsByteURLTests: XCTestCase {
         XCTAssertEqual(url.writtenBytes, 64)
     }
 
+    func testByteURL_whenInitWithBufferSlice() {
+        // Given
+        var buffer = ByteBuffer(data: .randomData(length: 128))
+
+        buffer.moveReaderIndex(to: 64)
+
+        // When
+        let url = Internals.ByteURL(buffer)
+
+        // Then
+        XCTAssertEqual(url.buffer.writerIndex, 64)
+        XCTAssertEqual(url.buffer.readerIndex, .zero)
+        XCTAssertEqual(url.writtenBytes, 64)
+    }
+
     func testByteURL_whenEquals() {
         // Given
         let url = Internals.ByteURL()


### PR DESCRIPTION
## Description

<!--- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
-->

Fix the way that ByteURL was init internally to use the `slice()` method implemented by `NIOCore` which results in a piece of ByteBuffer with the right values for `readerIndex` and `writerIndex`

Fixes **None**

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Please delete options that are not relevant. -->

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
