### PR TITLE
Fix Log console print

### DIFF
--- a/Sources/RequestDL/Internals/Sources/Log/Log/Internals.Log.swift
+++ b/Sources/RequestDL/Internals/Sources/Log/Log/Internals.Log.swift
@@ -60,7 +60,7 @@ extension Internals.Log {
 extension Internals.Log {
 
     fileprivate static func log(
-        _ items: Any...,
+        _ items: [Any],
         level: Level,
         separator: String,
         line: UInt,


### PR DESCRIPTION
## Description

There was an issue with printing the debug messages in console. This was fixed changing the type of items in internal log code