### PR TITLE
Fix PropertyBuilder buildIf to use the correct buildOptional name

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Result Builder/Property Builder/PropertyBuilder.swift
+++ b/Sources/RequestDL/Properties/Sources/Result Builder/Property Builder/PropertyBuilder.swift
@@ -66,7 +66,7 @@ public struct PropertyBuilder: Sendable {
     }
 
     /// A helper method for the `PropertyBuilder` to include optional content in the result builder.
-    public static func buildIf<Content: Property>(_ content: Content?) -> _OptionalContent<Content> {
+    public static func buildOptional<Content: Property>(_ content: Content?) -> _OptionalContent<Content> {
         _OptionalContent(content)
     }
 


### PR DESCRIPTION
## Summary
- `@resultBuilder` only recognizes `buildOptional(_:)` as the customization point for `if`-without-`else` blocks; `buildIf` is not picked up by the compiler.
- Renames `PropertyBuilder.buildIf` to `PropertyBuilder.buildOptional`, fixing a bare `if` inside a `@PropertyBuilder` closure (without an `else` branch) that previously failed to compile.
- Found while auditing the `tls-pinning` branch's diff against `main`; this fix is unrelated to TLS pinning, so it's split out here.

## Test plan
- [x] `swift build`
- [x] `swift test --filter RequestDLTests.PropertyBuilderTests`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01KE8DNnGTgGGpAKjeutxEnV