### PR TITLE
Store DataCache's default location in Library/Caches on Darwin, not tmp

### DIFF
--- a/Sources/RequestDL/Internals/Extensions/FilePath+.swift
+++ b/Sources/RequestDL/Internals/Extensions/FilePath+.swift
@@ -10,6 +10,10 @@ import FoundationEssentials
 import class Foundation.ProcessInfo
 #endif
 
+#if canImport(Darwin)
+import class Foundation.FileManager
+#endif
+
 extension FilePath {
 
     /// The system temporary directory.
@@ -51,5 +55,27 @@ extension FilePath {
         #else
         return FilePath("/private/tmp")
         #endif
+    }
+
+    /// The directory appropriate for data that should persist between launches but can be
+    /// regenerated, such as the on-disk cache.
+    ///
+    /// Apple's guidance is explicit about this split: the temporary directory can be purged by
+    /// the system at any moment, including while the app is still running, so anything that
+    /// needs to survive past the current request does not belong there. `Library/Caches` is
+    /// still purgeable under disk pressure, but only between launches, which is what a cache
+    /// actually wants.
+    ///
+    /// `FileManager` is not part of `FoundationEssentials`, so this only resolves through it on
+    /// Darwin, where the full `Foundation` is available. Everywhere else there is no equivalent
+    /// standard location, so this falls back to ``temporaryDirectory``.
+    static var cachesDirectory: FilePath {
+        #if canImport(Darwin)
+        if let url = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first {
+            return FilePath(url.path)
+        }
+        #endif
+
+        return temporaryDirectory
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Cache/Data Cache/DataCache.swift
+++ b/Sources/RequestDL/Properties/Sources/Cache/Data Cache/DataCache.swift
@@ -277,16 +277,19 @@ public struct DataCache: Sendable, Equatable {
 
     /// The cache directory for a given suite.
     ///
-    /// - Note: The temporary directory comes from ``SystemPackage/FilePath/temporaryDirectory``,
-    /// not from `FileManager`, which is not part of `FoundationEssentials`. On Darwin both
-    /// resolve to `TMPDIR`, so the location does not move.
+    /// - Note: Resolved through ``SystemPackage/FilePath/cachesDirectory``, not
+    /// `FilePath.temporaryDirectory``. Cache entries are meant to survive between requests, and
+    /// the temporary directory offers no such guarantee: the system can purge it at any moment,
+    /// even while the app is running. `cachesDirectory` lands in `Library/Caches` on Darwin,
+    /// which is only cleared between launches, and falls back to the temporary directory on
+    /// platforms with no equivalent standard location.
     ///
-    ///   `FileSystem.shared.temporaryDirectory` is the NIO one and would be the obvious choice,
-    ///   but it is `async throws` and this call chain cannot suspend: it is reached from
+    ///   `FileSystem.shared.temporaryDirectory` is the NIO one and would otherwise be the obvious
+    ///   choice, but it is `async throws` and this call chain cannot suspend: it is reached from
     ///   `public init(...)` and, through those, from `public static let shared = DataCache()`.
     ///   A stored property cannot be initialised from an asynchronous call.
     static func temporaryURL(suiteName: String) -> URL {
-        URL(fileURLWithPath: FilePath.temporaryDirectory.string, isDirectory: true)
+        URL(fileURLWithPath: FilePath.cachesDirectory.string, isDirectory: true)
             .appendingPathComponent(
                 "com.request-dl-nio.Swift.Cache",
                 isDirectory: true


### PR DESCRIPTION
## Summary
- `DataCache`'s default (no explicit `url`) storage location resolved into the system temporary directory (`/private/tmp` on Darwin), which the OS can purge at any moment even while the app is running.
- Adds `FilePath.cachesDirectory`, which resolves to `Library/Caches` via `FileManager` on Darwin and falls back to the existing temporary-directory logic elsewhere (no `FileManager` equivalent off-Darwin).
- `DataCache.temporaryURL(suiteName:)` now builds its base path from `cachesDirectory` instead of `temporaryDirectory`.

## Test plan
- [x] `swift build`
- [x] `swift test --filter DataCacheTests` (16/16 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197bpNtKaUoPoSECuffWCmZ