### PR TITLE
Explicitly set defaultIsolation(nil) on RequestDL target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -77,7 +77,8 @@ let package = Package(
                 .product(name: "SystemPackage", package: "swift-system"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Collections", package: "swift-collections"),
-            ]
+            ],
+            swiftSettings: [.defaultIsolation(nil)],
         ),
 
         .testTarget(


### PR DESCRIPTION
## Summary
- Sets `swiftSettings: [.defaultIsolation(nil)]` on the `RequestDL` target so the module stays `nonisolated` by default, independent of any future toolchain/SwiftPM default (Swift 6.2 / SE-0466 allows a module to default to `MainActor` isolation).
- RequestDL's internals run off NIO event loops and rely on nonisolated-by-default semantics, so this makes that assumption explicit rather than implicit.

## Test plan
- [x] `swift build` succeeds
- [ ] CI (formatting, API-breaking-changes check, Apple + Linux test suites)