### PR TITLE
Add URLOverride for request-level scheme/host/path rewriting

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Graph/Resolve/Models/Make.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Resolve/Models/Make.swift
@@ -17,6 +17,13 @@ struct Make: Sendable {
     /// `sessionConfiguration`, and that is what the client cache keys on.
     var resolvesSystemProxy: Bool
 
+    /// Rules accumulated by every declared `URLOverride`, in declaration order.
+    ///
+    /// Matched against the final `baseURL`/`pathComponents` in `Resolve.build()`, once every
+    /// property (including whichever `BaseURL` wins) has contributed — matching here, while the
+    /// tree is still being walked, could still miss a `BaseURL` or `Path` declared later.
+    var urlOverrides: [URLOverrideRule]
+
     // MARK: - Inits
 
     init(
@@ -28,5 +35,6 @@ struct Make: Sendable {
         self.requestConfiguration = requestConfiguration
         self.cacheConfiguration = .init()
         self.resolvesSystemProxy = false
+        self.urlOverrides = []
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Graph/Resolve/Resolve.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Resolve/Resolve.swift
@@ -22,7 +22,8 @@ struct Resolve<Root: Property>: Sendable {
     // MARK: - Internal methods
 
     func build() async throws -> Resolved {
-        let (_, make) = try await partiallyBuild()
+        var (_, make) = try await partiallyBuild()
+        applyingURLOverride(&make)
 
         let session = Internals.Session(
             provider: make.provider ?? .shared,
@@ -88,6 +89,51 @@ struct Resolve<Root: Property>: Sendable {
         )
 
         return configuration
+    }
+
+    /// Rewrites `baseURL`/`pathComponents` per the last-declared `URLOverride` rule whose origin
+    /// (scheme + host + optional path prefix) matches the final resolved request.
+    ///
+    /// Done here rather than inside `URLOverride`'s node for the same reason system-proxy
+    /// resolution is: matching needs the final `baseURL`/`pathComponents`, complete only once
+    /// every property (including whichever `BaseURL` wins) has contributed. Runs before
+    /// `sessionConfiguration(for:)` so a resolved system proxy answers for the overridden
+    /// destination, not the original one.
+    private func applyingURLOverride(_ make: inout Make) {
+        guard
+            !make.urlOverrides.isEmpty,
+            let origin = URLOverrideEndpoint(baseURL: make.requestConfiguration.baseURL)
+        else {
+            return
+        }
+
+        let pathComponents = Array(
+            make.requestConfiguration.pathComponents
+                .joinedAsPath()
+                .split(separator: "/")
+                .map(String.init)
+        )
+
+        var match: (destination: URLOverrideEndpoint, remainder: [String])?
+
+        for rule in make.urlOverrides {
+            guard
+                rule.origin.scheme == origin.scheme,
+                rule.origin.host == origin.host,
+                pathComponents.starts(with: rule.origin.pathComponents)
+            else {
+                continue
+            }
+
+            match = (rule.destination, Array(pathComponents.dropFirst(rule.origin.pathComponents.count)))
+        }
+
+        guard let (destination, remainder) = match else {
+            return
+        }
+
+        make.requestConfiguration.baseURL = "\(destination.scheme)://\(destination.host)"
+        make.requestConfiguration.pathComponents = destination.pathComponents + remainder
     }
 
     private func inputs() -> _PropertyInputs {

--- a/Sources/RequestDL/Properties/Sources/Session/URL Override/Models/URLOverrideEndpoint.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/URL Override/Models/URLOverrideEndpoint.swift
@@ -1,0 +1,79 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.URL
+import struct Foundation.URLComponents
+#endif
+
+/// The parsed `"scheme://host[/path]"` shape shared by both sides of a `URLOverride` rule.
+struct URLOverrideEndpoint: Sendable, Equatable {
+
+    let scheme: String
+    let host: String
+    let pathComponents: [String]
+}
+
+extension URLOverrideEndpoint {
+
+    /// Parses a user-supplied origin/destination string.
+    ///
+    /// A bare host (no `"scheme://"`) is rejected rather than defaulted, unlike ``BaseURL`` or
+    /// ``FlexibleURL`` — with two strings per rule instead of one, an implicit scheme would make
+    /// it ambiguous which side of the pair a validation failure came from.
+    init(parsing url: String) throws {
+        // `Character.isWhitespace` already covers newlines, so this is the whole of
+        // `.whitespacesAndNewlines` without needing `Foundation.CharacterSet`.
+        let normalized = url.trimming(where: \.isWhitespace)
+
+        guard let parsedURL = URL(string: normalized),
+            let components = URLComponents(url: parsedURL, resolvingAgainstBaseURL: false)
+        else {
+            throw URLOverrideError(context: .invalidURL, url: url)
+        }
+
+        guard let scheme = components.scheme, !scheme.isEmpty else {
+            throw URLOverrideError(context: .missingScheme, url: url)
+        }
+
+        guard let host = components.host, !host.isEmpty else {
+            throw URLOverrideError(context: .missingHost, url: url)
+        }
+
+        self.scheme = scheme
+        self.host = host
+        self.pathComponents = Array(
+            components.path
+                .split(separator: "/")
+                .lazy
+                .filter { !$0.isEmpty }
+                .map(String.init)
+        )
+    }
+
+    /// Parses an already-normalized `"scheme://host"` request base URL (see
+    /// `RequestConfiguration.baseURL`/``BaseURL``) for matching against a rule's origin.
+    ///
+    /// Returns `nil` instead of throwing for an empty/malformed value (e.g. no ``BaseURL``
+    /// declared) — this runs after the property tree has already fully resolved, past the point
+    /// where a `Property` can still fail the build; an unmatched request should just pass through.
+    init?(baseURL: String) {
+        guard let separatorRange = baseURL.range(of: "://") else {
+            return nil
+        }
+
+        let scheme = String(baseURL[..<separatorRange.lowerBound])
+        let host = String(baseURL[separatorRange.upperBound...])
+
+        guard !scheme.isEmpty, !host.isEmpty else {
+            return nil
+        }
+
+        self.scheme = scheme
+        self.host = host
+        self.pathComponents = []
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Session/URL Override/Models/URLOverrideEndpoint.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/URL Override/Models/URLOverrideEndpoint.swift
@@ -61,12 +61,22 @@ extension URLOverrideEndpoint {
     /// declared) — this runs after the property tree has already fully resolved, past the point
     /// where a `Property` can still fail the build; an unmatched request should just pass through.
     init?(baseURL: String) {
-        guard let separatorRange = baseURL.range(of: "://") else {
+        // Neither `range(of:)` (a Foundation member this file has no import for) nor
+        // `firstRange(of:)`/`contains(_:)` for a substring pattern (stdlib, but gated to
+        // macOS 13/iOS 16 — newer than this package's macOS 12/iOS 15 minimum). A single
+        // `Character` lookup plus `hasPrefix` has neither restriction.
+        guard let colonIndex = baseURL.firstIndex(of: ":") else {
             return nil
         }
 
-        let scheme = String(baseURL[..<separatorRange.lowerBound])
-        let host = String(baseURL[separatorRange.upperBound...])
+        let afterColon = baseURL.index(after: colonIndex)
+
+        guard baseURL[afterColon...].hasPrefix("//") else {
+            return nil
+        }
+
+        let scheme = String(baseURL[..<colonIndex])
+        let host = String(baseURL[baseURL.index(afterColon, offsetBy: 2)...])
 
         guard !scheme.isEmpty, !host.isEmpty else {
             return nil

--- a/Sources/RequestDL/Properties/Sources/Session/URL Override/Models/URLOverrideError.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/URL Override/Models/URLOverrideError.swift
@@ -1,0 +1,47 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+/// An error type thrown by the `URLOverride` property when an origin or destination string
+/// cannot be parsed.
+///
+/// This error provides context about the specific reason the string could not be processed.
+public struct URLOverrideError: Error {
+
+    ///
+    /// Defines the specific context or reason why the `URLOverride` processing failed.
+    ///
+    /// - `invalidURL`: Indicates that the provided string could not be parsed as a valid URL structure.
+    /// - `missingScheme`: Indicates the string did not include a scheme (e.g. `"https"`).
+    /// - `missingHost`: Indicates the string did not include a host.
+    ///
+    public enum Context: Sendable {
+        /// The provided string could not be interpreted as a valid URL.
+        case invalidURL
+        /// The scheme component was missing or empty.
+        case missingScheme
+        /// The host component was missing or empty.
+        case missingHost
+    }
+
+    /// The contextual reason for the error.
+    public let context: Context
+
+    /// The original string that caused the error.
+    public let url: String
+
+    ///
+    /// Creates a new `URLOverrideError`.
+    ///
+    /// - Parameters:
+    ///   - context: The reason for the error (e.g. invalid URL or a missing scheme/host).
+    ///   - url: The string that led to the error.
+    ///
+    public init(
+        context: Context,
+        url: String
+    ) {
+        self.context = context
+        self.url = url
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Session/URL Override/Models/URLOverrideRule.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/URL Override/Models/URLOverrideRule.swift
@@ -1,0 +1,10 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+/// A single parsed origin/destination pair accumulated by ``URLOverride``.
+struct URLOverrideRule: Sendable {
+
+    let origin: URLOverrideEndpoint
+    let destination: URLOverrideEndpoint
+}

--- a/Sources/RequestDL/Properties/Sources/Session/URL Override/URLOverride.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/URL Override/URLOverride.swift
@@ -1,0 +1,121 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+/// `URLOverride` rewrites a request's scheme, host, and optionally a path prefix to a different
+/// destination, resolved before the request executes.
+///
+/// ```swift
+/// DataTask {
+///     BaseURL("google.com")
+///     URLOverride("https://apple.com", from: "https://google.com")
+/// }
+/// // executes against apple.com
+/// ```
+///
+/// Unlike ``DNSOverride``, which redirects the connection while keeping the request's `Host`
+/// header and TLS SNI pointed at the original hostname, `URLOverride` rewrites the request
+/// itself: the destination server sees `Host: apple.com` and gets real TLS certificate validation
+/// against its own certificate, not the origin's. This makes it suited to migrating an API to a
+/// new domain without touching every ``BaseURL`` call site, environment overrides, or staged
+/// domain cutovers — not to bypassing DNS or tunneling through an intermediary, which is what
+/// ``DNSOverride``/``Proxy`` are for.
+///
+/// It is also unrelated to `Session.disableRedirect()`/`.enableRedirectFollow(...)`, despite the
+/// naming proximity — those follow HTTP 3xx responses returned by the server; `URLOverride` never
+/// sees a 3xx, it rewrites the request before it is ever sent.
+///
+/// Both initializers take full `"scheme://host[/path]"` strings — never a bare host — so the
+/// `://` keeps parsing unambiguous and the scheme mandatory, the same way ``BaseURL`` validates
+/// its own host string.
+///
+/// ```swift
+/// // Single pair — composes with @PropertyBuilder conditionals (if/else picking one override)
+/// URLOverride("https://apple.com", from: "https://google.com")
+///
+/// // Dictionary — bulk declaration of the whole table up front
+/// URLOverride([
+///     "https://google.com": "https://apple.com",
+///     "https://google.com/api/v1": "https://apple.com/v2",
+/// ])
+/// ```
+///
+/// The origin's path, if present, is matched as a prefix of path components, not a raw string, so
+/// `api/v1` never accidentally matches `api/v10`. On a match, the matched leading path components
+/// are replaced with the destination's; the remainder of the path and the query string pass
+/// through untouched.
+///
+/// > Note: A destination is never re-matched against other `URLOverride` rules — there is no
+/// > chaining, which avoids override loops.
+///
+/// > Note: The last-declared rule wins for a given origin, the same convention ``BaseURL`` and
+/// > ``DNSOverride`` already use. If two declared rules have a genuinely overlapping-but-different
+/// > scope for the same host (e.g. a whole-host rule and a path-scoped rule both declared), which
+/// > one applies is left undefined rather than adding specificity-ordering complexity.
+public struct URLOverride: Property {
+
+    private struct Node: PropertyNode {
+
+        let pairs: [(origin: String, destination: String)]
+
+        func make(_ make: inout Make) async throws {
+            for pair in pairs {
+                make.urlOverrides.append(
+                    URLOverrideRule(
+                        origin: try URLOverrideEndpoint(parsing: pair.origin),
+                        destination: try URLOverrideEndpoint(parsing: pair.destination)
+                    )
+                )
+            }
+        }
+    }
+
+    // MARK: - Public properties
+
+    /// Returns an exception since `Never` is a type that can never be constructed.
+    public var body: Never {
+        bodyException()
+    }
+
+    // MARK: - Internal properties
+
+    let pairs: [(origin: String, destination: String)]
+
+    // MARK: - Inits
+
+    ///
+    /// Initializes a new instance of `URLOverride` mapping a single origin to a destination.
+    ///
+    /// - Parameters:
+    ///    - destination: The full `"scheme://host[/path]"` requests matching `origin` are rewritten to.
+    ///    - origin: The full `"scheme://host[/path]"` to match against the resolved request.
+    ///
+    /// > Note: The parameter order is `(_ destination, from origin)`, meaning `origin` requests
+    /// resolve to `destination`, mirroring ``DNSOverride``.
+    ///
+    public init(_ destination: String, from origin: String) {
+        self.pairs = [(origin: origin, destination: destination)]
+    }
+
+    ///
+    /// Initializes a new instance of `URLOverride` declaring the whole origin-to-destination
+    /// table at once.
+    ///
+    /// - Parameter overrides: A dictionary keyed by the full `"scheme://host[/path]"` origin,
+    /// valued by the full `"scheme://host[/path]"` destination it resolves to.
+    ///
+    public init(_ overrides: [String: String]) {
+        self.pairs = overrides.map { (origin: $0.key, destination: $0.value) }
+    }
+
+    // MARK: - Public static methods
+
+    /// This method is used internally and should not be called directly.
+    public static func _makeProperty(
+        property: _GraphValue<URLOverride>,
+        inputs: _PropertyInputs
+    ) async throws -> _PropertyOutputs {
+        property.assertPathway()
+        return .leaf(Node(pairs: property.pairs))
+    }
+}

--- a/Tests/RequestDLTests/Properties/Sources/Session/URLOverride/URLOverrideTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Session/URLOverride/URLOverrideTests.swift
@@ -1,0 +1,269 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Testing
+
+@testable import RequestDL
+
+struct URLOverrideTests {
+
+    @Test
+    func hostOnlyOverride() async throws {
+        // Given / When
+        let resolved = try await resolve(
+            TestProperty {
+                BaseURL("google.com")
+                URLOverride("https://apple.com", from: "https://google.com")
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.url == "https://apple.com")
+    }
+
+    @Test
+    func pathPrefixOverride_replacesMatchedPrefixAndKeepsRemainder() async throws {
+        // Given / When
+        let resolved = try await resolve(
+            TestProperty {
+                BaseURL("google.com")
+                Path("api/v1")
+                Path("users")
+                URLOverride("https://apple.com/v2", from: "https://google.com/api/v1")
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.url == "https://apple.com/v2/users")
+    }
+
+    @Test
+    func pathPrefixOverride_keepsQueryUntouched() async throws {
+        // Given / When
+        let resolved = try await resolve(
+            TestProperty {
+                BaseURL("google.com")
+                Path("api/v1")
+                Query(name: "id", value: 42)
+                URLOverride("https://apple.com/v2", from: "https://google.com/api/v1")
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.url == "https://apple.com/v2?id=42")
+    }
+
+    @Test
+    func pathPrefixOverride_matchesByComponentNotRawString() async throws {
+        // Given / When — "api/v10" must not be treated as prefixed by "api/v1".
+        let resolved = try await resolve(
+            TestProperty {
+                BaseURL("google.com")
+                Path("api/v10")
+                URLOverride("https://apple.com/v2", from: "https://google.com/api/v1")
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.url == "https://google.com/api/v10")
+    }
+
+    @Test
+    func override_appliesAgainstFinalBaseURL_regardlessOfDeclarationOrder() async throws {
+        // Given / When — `URLOverride` declared before the `BaseURL` that ends up winning.
+        let resolved = try await resolve(
+            TestProperty {
+                URLOverride("https://apple.com", from: "https://google.com")
+                BaseURL(.ftp, host: "unrelated.com")
+                BaseURL("google.com")
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.url == "https://apple.com")
+    }
+
+    @Test
+    func unmatchedOrigin_leavesRequestUnchanged() async throws {
+        // Given / When
+        let resolved = try await resolve(
+            TestProperty {
+                BaseURL("example.com")
+                URLOverride("https://apple.com", from: "https://google.com")
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.url == "https://example.com")
+    }
+
+    @Test
+    func lastDeclaredRuleWinsForSameOrigin() async throws {
+        // Given / When
+        let resolved = try await resolve(
+            TestProperty {
+                BaseURL("google.com")
+                URLOverride("https://first.com", from: "https://google.com")
+                URLOverride("https://second.com", from: "https://google.com")
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.url == "https://second.com")
+    }
+
+    @Test
+    func destinationIsNeverRematchedAgainstOtherRules() async throws {
+        // Given / When — a.com -> b.com is declared, and b.com -> c.com is declared, but a
+        // resolved request should stop at b.com rather than chaining through to c.com.
+        let resolved = try await resolve(
+            TestProperty {
+                BaseURL("a.com")
+                URLOverride("https://b.com", from: "https://a.com")
+                URLOverride("https://c.com", from: "https://b.com")
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.url == "https://b.com")
+    }
+
+    @Test
+    func dictionaryInitializer_appliesMatchingEntry() async throws {
+        // Given / When — non-overlapping origins, so the dictionary's unspecified iteration
+        // order can't make the match ambiguous (overlapping scopes are documented as undefined).
+        let resolved = try await resolve(
+            TestProperty {
+                BaseURL("google.com")
+                Path("api/v1")
+                URLOverride([
+                    "https://google.com/api/v1": "https://apple.com/v2",
+                    "https://example.com": "https://unused.com",
+                ])
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.url == "https://apple.com/v2")
+    }
+
+    @Test
+    func originScheme_mustMatch() async throws {
+        // Given / When
+        let resolved = try await resolve(
+            TestProperty {
+                BaseURL(.http, host: "google.com")
+                URLOverride("https://apple.com", from: "https://google.com")
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.url == "http://google.com")
+    }
+
+    @Test
+    func origin_whenMissingScheme_throws() async throws {
+        // Given
+        let origin = "google.com"
+
+        do {
+            // When
+            _ = try await resolve(
+                TestProperty {
+                    BaseURL("google.com")
+                    URLOverride("https://apple.com", from: origin)
+                }
+            )
+
+            // Then
+            Issue.record("Not expecting success")
+        } catch let error as URLOverrideError {
+            #expect(error.context == .missingScheme)
+            #expect(error.url == origin)
+        } catch {
+            throw error
+        }
+    }
+
+    @Test
+    func destination_whenMissingScheme_throws() async throws {
+        // Given
+        let destination = "apple.com"
+
+        do {
+            // When
+            _ = try await resolve(
+                TestProperty {
+                    BaseURL("google.com")
+                    URLOverride(destination, from: "https://google.com")
+                }
+            )
+
+            // Then
+            Issue.record("Not expecting success")
+        } catch let error as URLOverrideError {
+            #expect(error.context == .missingScheme)
+            #expect(error.url == destination)
+        } catch {
+            throw error
+        }
+    }
+
+    @Test
+    func origin_whenMissingHost_throws() async throws {
+        // Given
+        let origin = "https://"
+
+        do {
+            // When
+            _ = try await resolve(
+                TestProperty {
+                    BaseURL("google.com")
+                    URLOverride("https://apple.com", from: origin)
+                }
+            )
+
+            // Then
+            Issue.record("Not expecting success")
+        } catch let error as URLOverrideError {
+            #expect(error.context == .missingHost)
+            #expect(error.url == origin)
+        } catch {
+            throw error
+        }
+    }
+
+    @Test
+    func origin_whenEmptyString_throws() async throws {
+        // Given
+        let origin = ""
+
+        do {
+            // When
+            _ = try await resolve(
+                TestProperty {
+                    BaseURL("google.com")
+                    URLOverride("https://apple.com", from: origin)
+                }
+            )
+
+            // Then
+            Issue.record("Not expecting success")
+        } catch let error as URLOverrideError {
+            #expect(error.context == .invalidURL)
+            #expect(error.url == origin)
+        } catch {
+            throw error
+        }
+    }
+
+    @Test
+    func neverBody() async throws {
+        // Given
+        let property = URLOverride("https://apple.com", from: "https://google.com")
+
+        // Then
+        try await assertNever(property.body)
+    }
+}


### PR DESCRIPTION
## Summary
- Implements `URLOverride`, closing the scope agreed in [discussions#199](https://github.com/orgs/request-dl/discussions/199): a request declared against one origin can be rewritten to a different scheme/host and optional path prefix *before* it executes.
- Distinct from `DNSOverride` (keeps `Host`/SNI pointed at the origin) and `Proxy` (keeps the target URL) — `URLOverride` rewrites the request itself, so the destination server sees its own `Host` and gets real TLS validation against its own certificate.
- Matching is deferred to `Resolve.build()`, after the full property tree is walked, mirroring `SystemProxy`'s late-binding pattern — so it works regardless of where `URLOverride` is declared relative to the winning `BaseURL`/`Path`.
- Origin path matching works on path components, not raw strings (`api/v1` never accidentally matches `api/v10`). No chaining (a destination is never re-matched against other rules). Last-declared rule wins for a given origin.
- Both initializers from the discussion: `URLOverride(_:from:)` for a single pair, `URLOverride([String: String])` for the whole table at once.

## Test plan
- [x] `swift test` — full suite (1073 tests) passes
- [x] `swift format lint --recursive --strict Sources Tests` — clean
- [x] New `URLOverrideTests` (15 tests): host-only + path-prefix rewrites, query passthrough, component-boundary correctness, declaration-order independence, no-chaining, dictionary form, and all error paths (invalid URL, missing scheme, missing host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)