### PR TITLE
Add PayloadEncoder for pluggable payload serialization

### DIFF
--- a/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Essentials/Exploring-payload.md
+++ b/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Essentials/Exploring-payload.md
@@ -14,6 +14,8 @@ That's why RequestDL provides ``RequestDL/Payload`` and ``RequestDL/Form`` to ma
 
 > Tip: Each object has 5 initializers that standardize data configuration in a request: Data, String, URL, Codable, and JSON (also known as [String: Any]).
 
+> Tip: Need a serialization format other than JSON, such as Protobuf or MessagePack? Implement ``RequestDL/PayloadEncoder`` and pass it to `Payload(_:encoder:contentType:)`.
+
 ### Payload
 
 We can consider ``RequestDL/Payload`` as the primitive type for the bytes to be sent in a request. Keep in mind the following 3 central properties of every payload:
@@ -67,6 +69,7 @@ Payload(userModel, contentType: .formURLEncoded)
 ### Inserting bytes in the request body
 
 - ``RequestDL/Payload``
+- ``RequestDL/PayloadEncoder``
 - ``RequestDL/EncodingPayloadError``
 
 ### Using the multipart form data

--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/PayloadEncoder.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/PayloadEncoder.swift
@@ -1,0 +1,48 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.Data
+#endif
+
+/// A pluggable serialization format for ``Payload``.
+///
+/// `PayloadEncoder` lets a value be turned into the bytes of a request body using a format other
+/// than JSON — Protobuf, MessagePack, or any other serializer a consumer wants to plug in — the
+/// same way `Payload(_:encoder:contentType:)` already does for `Encodable` + `JSONEncoder`.
+///
+/// ```swift
+/// struct ProtobufEncodingError: Error {}
+///
+/// struct ProtobufPayloadEncoder: PayloadEncoder {
+///     var contentType: ContentType = "application/x-protobuf"
+///
+///     func encode<T: Sendable>(_ value: T) throws -> Data {
+///         guard let message = value as? SwiftProtobuf.Message else {
+///             throw ProtobufEncodingError()
+///         }
+///         return try message.serializedData()
+///     }
+/// }
+///
+/// DataTask {
+///     BaseURL("apple.com")
+///     RequestMethod(.post)
+///     Payload(myProtoMessage, encoder: ProtobufPayloadEncoder())
+/// }
+/// ```
+///
+/// - Important: `encode(_:)` turns a value into a single, complete `Data` blob. A serializer
+/// operates on a typed value, not on an arbitrary file — sending an existing file verbatim is
+/// already covered by ``Payload/init(url:contentType:)``.
+public protocol PayloadEncoder: Sendable {
+
+    /// The content type declared for the encoded body, unless the caller overrides it.
+    var contentType: ContentType { get }
+
+    /// Encodes `value` into the raw bytes of the request body.
+    func encode<T: Sendable>(_ value: T) throws -> Data
+}

--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/PayloadEncoderFactory.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/PayloadEncoderFactory.swift
@@ -1,0 +1,42 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.Data
+#endif
+
+struct PayloadEncoderFactory: Sendable, PayloadFactory {
+
+    // MARK: - Internal properties
+
+    let encode: @Sendable () throws -> Data
+    let contentType: ContentType
+
+    // MARK: - Inits
+
+    init<Value: Sendable, Encoder: PayloadEncoder>(
+        _ value: Value,
+        encoder: Encoder,
+        contentType: ContentType?
+    ) {
+        self.encode = { try encoder.encode(value) }
+        self.contentType = contentType ?? encoder.contentType
+    }
+
+    // MARK: - Internal methods
+
+    func callAsFunction(_ input: PayloadInput) async throws -> PayloadOutput {
+        // Unlike `EncodablePayloadFactory`, there is no form-urlencoded path here: a
+        // `PayloadEncoder` produces an opaque, atomic blob (Protobuf, MessagePack, ...), not a
+        // JSON object whose fields could be exploded into query items.
+        let data = try encode()
+
+        return await .init(
+            contentType: contentType,
+            source: .buffer(Internals.DataBuffer(data))
+        )
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload/Payload.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload/Payload.swift
@@ -52,6 +52,10 @@ import class Foundation.JSONSerialization
 ///
 /// - ``RequestDL/Payload/init(_:encoder:contentType:)``
 ///
+/// ### Sending values through a custom encoder
+///
+/// - ``RequestDL/PayloadEncoder``
+///
 /// ### Sending JSON objects
 ///
 /// - ``RequestDL/Payload/init(_:options:contentType:)``
@@ -107,6 +111,27 @@ public struct Payload: Property {
     ) {
         factory = EncodablePayloadFactory(
             object,
+            encoder: encoder,
+            contentType: contentType
+        )
+    }
+
+    ///
+    /// Initializes a `Payload` with a value serialized through a custom ``PayloadEncoder``.
+    ///
+    /// - Parameters:
+    ///    - value: The value to be serialized.
+    ///    - encoder: The encoder used to serialize `value`.
+    ///    - contentType: The content type of the payload. Defaults to the encoder's own
+    ///      ``PayloadEncoder/contentType``.
+    ///
+    public init<Value: Sendable, Encoder: PayloadEncoder>(
+        _ value: Value,
+        encoder: Encoder,
+        contentType: ContentType? = nil
+    ) {
+        factory = PayloadEncoderFactory(
+            value,
             encoder: encoder,
             contentType: contentType
         )

--- a/Tests/RequestDLTests/Properties/Sources/Payloads/Payload/Models/PayloadEncoderMock.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Payloads/Payload/Models/PayloadEncoderMock.swift
@@ -1,0 +1,36 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+@testable import RequestDL
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.Data
+#endif
+
+/// A `PayloadEncoder` stand-in for a third-party format (Protobuf, MessagePack, ...): it only
+/// knows how to encode `String`, so any other value exercises the error path.
+struct PayloadEncoderMock: PayloadEncoder {
+
+    // MARK: - Internal properties
+
+    let contentType: ContentType
+
+    // MARK: - Inits
+
+    init(contentType: ContentType = "application/x-mock") {
+        self.contentType = contentType
+    }
+
+    // MARK: - Internal methods
+
+    func encode<T: Sendable>(_ value: T) throws -> Data {
+        guard let string = value as? String else {
+            throw EncodingPayloadError(.invalidStringEncoding)
+        }
+
+        return Data(string.utf8)
+    }
+}

--- a/Tests/RequestDLTests/Properties/Sources/Payloads/Payload/PayloadTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Payloads/Payload/PayloadTests.swift
@@ -234,6 +234,92 @@ struct PayloadTests {
     }
 
     @Test
+    func payload_whenInitPayloadEncoder() async throws {
+        // Given
+        let verbatim = "Hello world!"
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Payload(
+                    verbatim,
+                    encoder: PayloadEncoderMock()
+                )
+            }
+        )
+
+        let data = try await resolved.requestConfiguration.body?.data()
+
+        // Then
+        #expect(
+            resolved.requestConfiguration.headers["Content-Type"] == ["application/x-mock"]
+        )
+
+        #expect(
+            resolved.requestConfiguration.headers["Content-Length"] == (data?.count).map { [String($0)] }
+        )
+
+        #expect(data == Data(verbatim.utf8))
+    }
+
+    @Test
+    func payload_whenInitPayloadEncoderWithCustomType() async throws {
+        // Given
+        let verbatim = "Hello world!"
+        let customType = ContentType("application/x-mock+request-dl")
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Payload(
+                    verbatim,
+                    encoder: PayloadEncoderMock(),
+                    contentType: customType
+                )
+            }
+        )
+
+        let data = try await resolved.requestConfiguration.body?.data()
+
+        // Then
+        // A `contentType` passed at the call site overrides the encoder's own
+        // `PayloadEncoder/contentType`.
+        #expect(
+            resolved.requestConfiguration.headers["Content-Type"] == [String(customType)]
+        )
+
+        #expect(
+            resolved.requestConfiguration.headers["Content-Length"] == (data?.count).map { [String($0)] }
+        )
+
+        #expect(data == Data(verbatim.utf8))
+    }
+
+    @Test
+    func payload_whenPayloadEncoderThrows() async throws {
+        // Given
+        var encodingError: EncodingPayloadError?
+
+        // When
+        do {
+            _ = try await resolve(
+                TestProperty {
+                    Payload(
+                        // Anything but a `String` triggers `PayloadEncoderMock`'s error path.
+                        42,
+                        encoder: PayloadEncoderMock()
+                    )
+                }
+            )
+        } catch let error as EncodingPayloadError {
+            encodingError = error
+        }
+
+        // Then
+        #expect(encodingError?.context == .invalidStringEncoding)
+    }
+
+    @Test
     func payload_whenInitString() async throws {
         // Given
         let verbatim = "Hello world!"


### PR DESCRIPTION
## Summary

- Adds `PayloadEncoder`, a public protocol that lets a value be serialized through a custom format (Protobuf, MessagePack, etc), the same way `Payload(_:encoder:contentType:)` already does today for `Encodable` + `JSONEncoder`.
- Adds `Payload(_:encoder:contentType:)` overload backed by `PayloadEncoderFactory`, which wraps the encoded bytes without a form-urlencoded path — a `PayloadEncoder` produces a single opaque, atomic blob, not a JSON object whose fields could be exploded into query items.
- Updates the Payload docc guide and topics to point at the new protocol.

Scope matches what was settled in the discussion:
- Value serialization only — no `.file(URL)` source (already covered by `Payload(url:contentType:)`).
- No chunked/streamed `encode` — a serialized message is atomic; `RequestBody` already streams the resulting `Data` on its own.
- Compression/encryption stay out of scope (byte-level transforms, not value serializers).

Ref: https://github.com/orgs/request-dl/discussions/196

## Test plan

- [x] `swift build`
- [x] `swift test` — 1061 tests, 168 suites, all passing
- [x] `swift format lint --recursive --strict Sources Tests`
- [x] New unit tests in `PayloadTests.swift` covering default content type (from the encoder), an overridden content type, and error propagation from the encoder