### PR TITLE
Add Payload(url:from:) for byte-offset uploads

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/FilePayloadFactory.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/FilePayloadFactory.swift
@@ -14,13 +14,41 @@ struct FilePayloadFactory: PayloadFactory {
 
     let url: URL
     let contentType: ContentType
+    let offset: UInt64
+
+    // MARK: - Inits
+
+    init(
+        url: URL,
+        contentType: ContentType,
+        offset: UInt64 = .zero
+    ) {
+        self.url = url
+        self.contentType = contentType
+        self.offset = offset
+    }
 
     // MARK: - Internal methods
 
     func callAsFunction(_ input: PayloadInput) async throws -> PayloadOutput {
-        await .init(
+        var buffer = await Internals.FileBuffer(url)
+
+        if offset > .zero {
+            let availableBytes = buffer.writerIndex
+
+            guard offset <= UInt64(availableBytes) else {
+                throw InvalidPayloadOffsetError(
+                    offset: offset,
+                    availableBytes: availableBytes
+                )
+            }
+
+            buffer.moveReaderIndex(to: Int(offset))
+        }
+
+        return .init(
             contentType: contentType,
-            source: .buffer(Internals.FileBuffer(url))
+            source: .buffer(buffer)
         )
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/InvalidPayloadOffsetError.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/InvalidPayloadOffsetError.swift
@@ -1,0 +1,29 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+/// An error thrown by ``RequestDL/Payload/init(url:from:contentType:)`` when the requested
+/// offset does not fit within the file's current size.
+///
+/// Typically means the file was truncated or replaced since the offset was recorded, e.g. by a
+/// previous, partially completed upload attempt.
+public struct InvalidPayloadOffsetError: Sendable, Error {
+
+    /// The offset that was requested.
+    public let offset: UInt64
+
+    /// The number of bytes available in the file at the time of the request.
+    public let availableBytes: Int
+
+    ///
+    /// Initializes a new instance of `InvalidPayloadOffsetError`.
+    ///
+    /// - Parameters:
+    ///    - offset: The offset that was requested.
+    ///    - availableBytes: The number of bytes available in the file at the time of the request.
+    ///
+    public init(offset: UInt64, availableBytes: Int) {
+        self.offset = offset
+        self.availableBytes = availableBytes
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload/Payload.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload/Payload.swift
@@ -47,6 +47,7 @@ import class Foundation.JSONSerialization
 /// ### Sending files
 ///
 /// - ``RequestDL/Payload/init(url:contentType:)``
+/// - ``RequestDL/Payload/init(url:from:contentType:)``
 ///
 /// ### Sending Encodable
 ///
@@ -160,6 +161,37 @@ public struct Payload: Property {
         factory = FilePayloadFactory(
             url: url,
             contentType: contentType
+        )
+    }
+
+    ///
+    /// Initializes a `Payload` with a file URL, starting the upload's byte stream at an
+    /// arbitrary offset instead of from the beginning of the file.
+    ///
+    /// This does not implement resumable upload by itself — HTTP has no universal mechanism for
+    /// that. It provides the one transport-agnostic building block a resume implementation needs:
+    /// a way to start streaming from a byte position other than zero. Track how many bytes were
+    /// sent (e.g. via ``UploadStep``), and on failure, start a fresh upload with a payload
+    /// beginning at that offset.
+    ///
+    /// - Parameters:
+    ///    - url: The file URL.
+    ///    - offset: The byte offset at which the upload's stream should start.
+    ///    - contentType: The content type of the payload.
+    ///
+    /// - Note: `offset` is only validated once the request is resolved, not at initialization
+    /// time. Resolving a request with a `Payload` whose offset is greater than the file's
+    /// current size throws ``InvalidPayloadOffsetError``.
+    ///
+    public init(
+        url: URL,
+        from offset: UInt64,
+        contentType: ContentType
+    ) {
+        factory = FilePayloadFactory(
+            url: url,
+            contentType: contentType,
+            offset: offset
         )
     }
 

--- a/Tests/RequestDLTests/Properties/Sources/Payloads/Payload/PayloadTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Payloads/Payload/PayloadTests.swift
@@ -487,6 +487,117 @@ struct PayloadTests {
     }
 
     @Test
+    func payload_whenInitURLWithOffset() async throws {
+        // Given
+        let data = await Data.randomData(length: 1_024 * 1_024)
+        let offset = 1_024 * 256
+
+        let url =
+            temporaryDirectoryURL
+            .appendingPathComponent("payload.\(UUID())")
+            .appendingPathExtension(".raw")
+
+        try await url.createPathIfNeeded()
+        defer { url.scheduleRemoval() }
+
+        try data.write(to: url)
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Payload(
+                    url: url,
+                    from: UInt64(offset),
+                    contentType: .octetStream
+                )
+            }
+        )
+
+        let builtData = try await resolved.requestConfiguration.body?.data()
+
+        // Then
+        #expect(
+            resolved.requestConfiguration.headers["Content-Type"] == ["application/octet-stream"]
+        )
+
+        #expect(
+            resolved.requestConfiguration.headers["Content-Length"] == [String(data.count - offset)]
+        )
+
+        #expect(builtData == data[offset...])
+    }
+
+    @Test
+    func payload_whenInitURLWithOffsetAtEndOfFile() async throws {
+        // Given
+        let data = await Data.randomData(length: 1_024)
+
+        let url =
+            temporaryDirectoryURL
+            .appendingPathComponent("payload.\(UUID())")
+            .appendingPathExtension(".raw")
+
+        try await url.createPathIfNeeded()
+        defer { url.scheduleRemoval() }
+
+        try data.write(to: url)
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Payload(
+                    url: url,
+                    from: UInt64(data.count),
+                    contentType: .octetStream
+                )
+            }
+        )
+
+        let builtData = try await resolved.requestConfiguration.body?.data()
+
+        // Then
+        #expect(resolved.requestConfiguration.headers["Content-Length"] == nil)
+        #expect(builtData == Data())
+    }
+
+    @Test
+    func payload_whenInitURLWithOffsetPastEndOfFile() async throws {
+        // Given
+        let data = await Data.randomData(length: 1_024)
+
+        let url =
+            temporaryDirectoryURL
+            .appendingPathComponent("payload.\(UUID())")
+            .appendingPathExtension(".raw")
+
+        try await url.createPathIfNeeded()
+        defer { url.scheduleRemoval() }
+
+        try data.write(to: url)
+
+        var offsetError: InvalidPayloadOffsetError?
+
+        // When
+        do {
+            _ = try await resolve(
+                TestProperty {
+                    Payload(
+                        url: url,
+                        from: UInt64(data.count) + 1,
+                        contentType: .octetStream
+                    )
+                }
+            )
+        } catch let error as InvalidPayloadOffsetError {
+            offsetError = error
+        }
+
+        // Then
+        #expect(offsetError?.offset == UInt64(data.count) + 1)
+        #expect(offsetError?.availableBytes == data.count)
+    }
+
+    @Test
     func payload_whenBodyCalled_shouldBeNever() async throws {
         // Given
         let property = Payload(data: Data())


### PR DESCRIPTION
## Summary
- Scopes down "resumable upload" (#204) to the one transport-agnostic piece that's actually implementable: starting a file upload's byte stream at an arbitrary offset.
- `Payload(url:from:contentType:)` seeks the file-backed buffer behind `FilePayloadFactory` to the given offset before streaming, reusing the existing absolute-offset `pread`/`pwrite` machinery — no new I/O primitive needed.
- `Content-Length` and `UploadStep.totalSize` correctly reflect the remaining bytes (derived from the buffer's `readableBytes`, not the full file size).
- An offset past the file's current size throws the new `InvalidPayloadOffsetError` at resolve time instead of trapping.
- Combined with the already-public `UploadStep` (reports `chunkSize`/`totalSize` per step), a consumer can track bytes sent and restart a failed upload with a payload beginning at that offset. The actual resume handshake with a specific backend (tus.io, S3, GCS, etc.) stays consumer-orchestrated, per the discussion's explicit scope.

Closes #204. Milestone: 4.1.0.

## Test plan
- [x] `swift build`
- [x] `swift format lint --recursive --strict Sources Tests`
- [x] `swift test --filter RequestDLTests.PayloadTests` (28 tests, including 3 new ones covering partial offset, offset-at-EOF, and offset-past-EOF)
- [x] Full `swift test` suite (1061 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)