### PR TITLE
Fail loudly when a Form/Payload file upload's URL can't be read

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/FilePayloadError.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/FilePayloadError.swift
@@ -1,0 +1,71 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.URL
+#endif
+
+/// An error thrown when RequestDL cannot read the file behind a `Form` or `Payload` file upload.
+///
+/// `Form(name:filename:contentType:url:)` and `Payload(url:contentType:)` both stream their body
+/// from disk through a file backed buffer that, by design, treats a missing or unreadable file
+/// as an empty one rather than failing — see `Internals.Buffer`. Left unchecked that turns a
+/// wrong `url` into a request sent with a silently empty body instead of an error anywhere near
+/// the mistake. This type exists to fail loudly instead, before that buffer is ever built.
+public struct FilePayloadError: Error, Sendable {
+
+    /// The specific reason the file could not be read.
+    public enum Context: Sendable {
+        /// No file exists at ``url``.
+        case notFound
+
+        /// A file exists at ``url``, but the file system refused to report on it — most often a
+        /// permissions problem.
+        case cantAccessFile(reason: any Error)
+    }
+
+    // MARK: - Public properties
+
+    /// The file `URL` that could not be read.
+    public let url: URL
+
+    /// The reason it could not be read.
+    public let context: Context
+
+    // MARK: - Inits
+
+    init(url: URL, context: Context) {
+        self.url = url
+        self.context = context
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension FilePayloadError: CustomStringConvertible {
+
+    public var description: String {
+        let path = url.absolutePath(percentEncoded: false)
+
+        switch context {
+        case .notFound:
+            return """
+                RequestDL couldn't read the file at "\(path)" for this Form/Payload upload: no \
+                file exists there.
+
+                Without this check, the request would have gone out with a silently empty body \
+                instead of the file's contents — a missing file has no error of its own to \
+                surface through the upload path. Double check how this URL was built: a file \
+                that ships inside your app bundle needs `Bundle.main.url(forResource:withExtension:)` \
+                (or the target's own resource bundle), not a path assembled by hand.
+                """
+        case .cantAccessFile(let reason):
+            return """
+                RequestDL couldn't read the file at "\(path)" for this Form/Payload upload: \(reason)
+                """
+        }
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/FilePayloadFactory.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/FilePayloadFactory.swift
@@ -18,9 +18,27 @@ struct FilePayloadFactory: PayloadFactory {
     // MARK: - Internal methods
 
     func callAsFunction(_ input: PayloadInput) async throws -> PayloadOutput {
-        await .init(
+        try await validateFileExists()
+
+        return await .init(
             contentType: contentType,
             source: .buffer(Internals.FileBuffer(url))
         )
+    }
+
+    // MARK: - Private methods
+
+    /// Confirms `url` can actually be read before handing it to `Internals.FileBuffer`, which
+    /// silently treats a missing or unreadable file as an empty one — see `Internals.Buffer`.
+    private func validateFileExists() async throws {
+        do {
+            guard try await Internals.fileSystem.info(forFileAt: url.filePath) != nil else {
+                throw FilePayloadError(url: url, context: .notFound)
+            }
+        } catch let error as FilePayloadError {
+            throw error
+        } catch {
+            throw FilePayloadError(url: url, context: .cantAccessFile(reason: error))
+        }
     }
 }

--- a/Tests/RequestDLTests/Properties/Sources/Payloads/Form/FormTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Payloads/Form/FormTests.swift
@@ -291,6 +291,37 @@ struct FormTests {
     }
 
     @Test
+    func form_whenInitURLFileDoesNotExist_shouldThrowFilePayloadError() async throws {
+        // Given
+        let url =
+            temporaryDirectoryURL
+            .appendingPathComponent("form.missing.\(UUID())")
+            .appendingPathExtension("raw")
+
+        // When
+        do {
+            _ = try await resolve(
+                TestProperty {
+                    Form(
+                        name: "foo",
+                        contentType: .pdf,
+                        url: url
+                    )
+                }
+            )
+            Issue.record("Not expecting success")
+        } catch let error as FilePayloadError {
+            // Then
+            #expect(error.url == url)
+
+            guard case .notFound = error.context else {
+                Issue.record("Expected .notFound, got \(error.context)")
+                return
+            }
+        }
+    }
+
+    @Test
     func form_whenInitURLWithFilename() async throws {
         // Given
         let name = "foo"

--- a/Tests/RequestDLTests/Properties/Sources/Payloads/Payload/PayloadTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Payloads/Payload/PayloadTests.swift
@@ -447,6 +447,36 @@ struct PayloadTests {
     }
 
     @Test
+    func payload_whenInitURLFileDoesNotExist_shouldThrowFilePayloadError() async throws {
+        // Given
+        let url =
+            temporaryDirectoryURL
+            .appendingPathComponent("payload.missing.\(UUID())")
+            .appendingPathExtension(".raw")
+
+        // When
+        do {
+            _ = try await resolve(
+                TestProperty {
+                    Payload(
+                        url: url,
+                        contentType: .octetStream
+                    )
+                }
+            )
+            Issue.record("Not expecting success")
+        } catch let error as FilePayloadError {
+            // Then
+            #expect(error.url == url)
+
+            guard case .notFound = error.context else {
+                Issue.record("Expected .notFound, got \(error.context)")
+                return
+            }
+        }
+    }
+
+    @Test
     func payload_whenInitURLWithCustomType() async throws {
         // Given
         let data = await Data.randomData(length: 1_024 * 1_024)


### PR DESCRIPTION
## Summary

- `Form(name:filename:contentType:url:)` and `Payload(url:contentType:)` both stream their body from disk through `Internals.FileBuffer` / `Internals.Buffer`, which — by explicit design (see its own doc comments) — treats a missing or unreadable file as an empty one rather than failing.
- In practice: pass a wrong `URL` and the request goes out with a **silently empty body**. No exception, no log, nothing — worse than the `Certificate`/`PrivateKey` case fixed in #268, since there isn't even a crash to notice.
- `FilePayloadFactory` now checks the file actually exists (via `Internals.fileSystem`, the same NIOFileSystem-backed layer already used elsewhere for file I/O in this codebase) before the buffer is ever constructed, and throws a new `FilePayloadError` — carrying the `url` and either `.notFound` or `.cantAccessFile(reason:)` (wrapping whatever `NIOFileSystem` reported, e.g. a permissions problem) — instead.

This is a separate, independent fix from #268: different root cause (a deliberately-silent buffer vs. NIOSSL's generic error), different call site (already `async throws`, so no need for the sync POSIX probing #268 needed), and a different new error type scoped to this call site. Branched fresh from `main` rather than stacked on #268 so the two can review and merge independently.

## Test plan

- [x] `swift build`
- [x] `swift test` (1060 tests passing)
- [x] `swift format lint --recursive --strict Sources Tests`
- [x] New tests: `Form(..., url:)` and `Payload(url:)` with a nonexistent file both throw `FilePayloadError` with `.notFound` and the right `url`

🤖 Generated with [Claude Code](https://claude.com/claude-code)