### PR TITLE
Relax AsyncLock.Watchdog thresholds to reduce CI flakiness

### DIFF
--- a/.github/workflows/swift-ci.yaml
+++ b/.github/workflows/swift-ci.yaml
@@ -52,6 +52,7 @@ jobs:
       package-name: "request-dl"
       xcode-version: '26.6'
       apple-coverage-enabled: true
+      apple-tests-parallel-testing-worker-count: '2'
 
       # Step 3 – Third Party
       enable-third-party-tests: true

--- a/Sources/RequestDL/Internals/Sources/Buffers/Buffer/Internals.Buffer.swift
+++ b/Sources/RequestDL/Internals/Sources/Buffers/Buffer/Internals.Buffer.swift
@@ -68,7 +68,7 @@ extension Internals {
 
             // MARK: - Private static properties
 
-            /// Flags a read/write/close/clear that is still running after 5s. Development
+            /// Flags a read/write/close/clear that is still running after 15s. Development
             /// builds only — see `AsyncLock.Watchdog`.
             ///
             /// - Note: Computed rather than a stored `static let` — `Storage` is nested inside
@@ -76,7 +76,7 @@ extension Internals {
             /// in a generic type.
             private static var watchdog: AsyncLock.Watchdog? {
                 #if DEBUG
-                .init(seconds: 5) { Internals.assertionFailure($0) }
+                .init(seconds: 15) { Internals.assertionFailure($0) }
                 #else
                 nil
                 #endif

--- a/Sources/RequestDL/Internals/Sources/Buffers/Buffer/Models/Internals.FileStreamBuffer.swift
+++ b/Sources/RequestDL/Internals/Sources/Buffers/Buffer/Models/Internals.FileStreamBuffer.swift
@@ -58,10 +58,10 @@ extension Internals {
 
         // MARK: - Private static properties
 
-        /// Flags a seek/read/write/close that is still running after 5s. Development builds
+        /// Flags a seek/read/write/close that is still running after 15s. Development builds
         /// only — see `AsyncLock.Watchdog`.
         #if DEBUG
-        private static let watchdog: AsyncLock.Watchdog? = .init(seconds: 5) {
+        private static let watchdog: AsyncLock.Watchdog? = .init(seconds: 15) {
             Internals.assertionFailure($0)
         }
         #else

--- a/Sources/RequestDL/Internals/Sources/Client/Client Manager/Internals.ClientManager.swift
+++ b/Sources/RequestDL/Internals/Sources/Client/Client Manager/Internals.ClientManager.swift
@@ -26,13 +26,13 @@ extension Internals {
         // MARK: - Private static properties
 
         /// Flags a `client(provider:sessionConfiguration:)` or `cleanupIfNeeded()` that is still
-        /// running after 30s. Set higher than the other `AsyncLock`s in `Internals`:
+        /// running after 45s. Set higher than the other `AsyncLock`s in `Internals`:
         /// `cleanupIfNeeded()` shares this lock and can shut down several expired clients
         /// serially in one sweep, each a real network drain, so a wide margin is needed to avoid
         /// flagging a legitimately busy sweep. Development builds only — see
         /// `AsyncLock.Watchdog`.
         #if DEBUG
-        private static let watchdog: AsyncLock.Watchdog? = .init(seconds: 30) {
+        private static let watchdog: AsyncLock.Watchdog? = .init(seconds: 45) {
             Internals.assertionFailure($0)
         }
         #else

--- a/Sources/RequestDL/Internals/Sources/Client/Client/Internals.Client.swift
+++ b/Sources/RequestDL/Internals/Sources/Client/Client/Internals.Client.swift
@@ -30,11 +30,11 @@ extension Internals {
 
         // MARK: - Private static properties
 
-        /// Flags a `shutdown()` that is still running after 10s — draining real, in-flight
+        /// Flags a `shutdown()` that is still running after 20s — draining real, in-flight
         /// connections can legitimately take a few seconds under load, longer than the other
         /// `AsyncLock`s in `Internals`. Development builds only — see `AsyncLock.Watchdog`.
         #if DEBUG
-        private static let watchdog: AsyncLock.Watchdog? = .init(seconds: 10) {
+        private static let watchdog: AsyncLock.Watchdog? = .init(seconds: 20) {
             Internals.assertionFailure($0)
         }
         #else

--- a/Sources/RequestDL/Internals/Sources/Session/Event Loop Manager/Internals.EventLoopGroupManager.swift
+++ b/Sources/RequestDL/Internals/Sources/Session/Event Loop Manager/Internals.EventLoopGroupManager.swift
@@ -16,10 +16,10 @@ extension Internals {
 
         // MARK: - Private static properties
 
-        /// Flags a `provider(_:with:)` that is still running after 5s. Development builds
+        /// Flags a `provider(_:with:)` that is still running after 15s. Development builds
         /// only — see `AsyncLock.Watchdog`.
         #if DEBUG
-        private static let watchdog: AsyncLock.Watchdog? = .init(seconds: 5) {
+        private static let watchdog: AsyncLock.Watchdog? = .init(seconds: 15) {
             Internals.assertionFailure($0)
         }
         #else


### PR DESCRIPTION
## Summary
- GitHub Actions macOS simulator runners (iOS/iPadOS/visionOS/watchOS) occasionally stall under scheduler/CPU contention long enough that a healthy `AsyncLock` critical section outlasts its `AsyncLock.Watchdog` deadline, tripping a `fatalError` and failing the job — even though the lock isn't actually deadlocked (a retry with zero code changes passes, and the same operations that "hung" for 5-10s in the failing run complete fine, just slower, once contention clears).
- Raises each watchdog threshold proportionally while keeping their relative ordering intact:
  - `Internals.Buffer`, `Internals.FileStreamBuffer`, `Internals.EventLoopGroupManager`: 5s → 15s
  - `Internals.Client.shutdown()`: 10s → 20s
  - `Internals.ClientManager` (already the highest by design): 30s → 45s
- Opts into the new `apple-tests-parallel-testing-worker-count` input from [request-dl/.github#92](https://github.com/request-dl/.github/pull/92) (merged), capping simulator worker clones at `2` to reduce the CPU/scheduler contention that's the underlying cause, rather than only raising the tolerance for it.

## Context
Investigated via PR #266's failing CI run (https://github.com/request-dl/request-dl-nio/actions/runs/31878613413) — only Apple *simulator* destinations failed (iOS/iPadOS/visionOS/watchOS); macOS, Mac Catalyst, tvOS and Linux all passed. The failing jobs' raw logs show the watchdog firing right as several suites finish concurrently, and a subsequent xcodebuild retry (same code) shows the "hung" operations completing in ~280s once the runner is less contended — consistent with runner-level CPU/scheduler contention, not a genuine deadlock introduced by recent changes.

This PR combines both mitigations: fewer simulator workers attacks the contention at the source, and the relaxed thresholds give headroom for whatever contention remains.

## Test plan
- [x] `swift build`
- [x] `swift format lint --recursive --strict Sources`
- [ ] CI green on iOS/iPadOS/visionOS/watchOS (previously flaky jobs)