### PR TITLE
Skip DiskStorage's directory rescan on writes nowhere near capacity

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Cache/Data Cache/DataCache.swift
+++ b/Sources/RequestDL/Properties/Sources/Cache/Data Cache/DataCache.swift
@@ -120,6 +120,15 @@ public struct DataCache: Sendable, Equatable {
         private var _memoryStorage: MemoryStorage
         private var _diskStorage: DiskStorage
 
+        /// Best-effort disk usage estimate, `nil` until first reconciled. Purely a hint for
+        /// `DiskStorage.freeSpace(_:knownUsage:)` to skip its directory rescan on the common
+        /// write that isn't anywhere near capacity — never relied on for correctness, so a
+        /// stale or absent value only costs an extra rescan, not a wrong eviction. Deliberately
+        /// left untouched by `remove`/`removeAll`/capacity changes: those only ever move usage
+        /// down or reset it, so an estimate that predates them is at worst a harmless
+        /// overcount that triggers one avoidable rescan next time. See #271.
+        private var _diskUsageEstimate: Int64?
+
         // MARK: - Internal methods
 
         /// Mutates the memory tier inside a single critical section.
@@ -133,6 +142,34 @@ public struct DataCache: Sendable, Equatable {
         /// storage from inside `body`, including the capacities.
         func withMemoryStorage<Output>(_ body: (inout MemoryStorage) -> Output) -> Output {
             lock.withLock { body(&_memoryStorage) }
+        }
+
+        /// Allocates a disk buffer, reusing `_diskUsageEstimate` so a write nowhere near
+        /// capacity can skip `DiskStorage.freeSpace`'s directory rescan. See that method and
+        /// `_diskUsageEstimate`'s doc for the safety argument behind reading and writing this
+        /// estimate outside the lock that guards it.
+        func allocateDiskBuffer(
+            key: String,
+            cachedResponse: CachedResponse,
+            contentLength: Int64
+        ) async -> Internals.AnyBuffer? {
+            let (diskStorage, maximumCapacity, knownUsage) = lock.withLock {
+                (_diskStorage, _diskCapacity, _diskUsageEstimate)
+            }
+
+            let (buffer, usage) = await diskStorage.allocateBuffer(
+                key: key,
+                cachedResponse: cachedResponse,
+                contentLength: contentLength,
+                maximumCapacity: maximumCapacity,
+                knownUsage: knownUsage
+            )
+
+            if let usage {
+                lock.withLock { _diskUsageEstimate = usage }
+            }
+
+            return buffer
         }
 
         // MARK: - Init
@@ -488,11 +525,10 @@ public struct DataCache: Sendable, Equatable {
         }
 
         if cachedResponse.policy.contains(.disk) {
-            diskBuffer = await storage.diskStorage.allocateBuffer(
+            diskBuffer = await storage.allocateDiskBuffer(
                 key: key,
                 cachedResponse: cachedResponse,
-                contentLength: contentLength,
-                maximumCapacity: diskCapacity
+                contentLength: contentLength
             )
         }
 

--- a/Sources/RequestDL/Properties/Sources/Cache/Data Cache/Models/DiskStorage.swift
+++ b/Sources/RequestDL/Properties/Sources/Cache/Data Cache/Models/DiskStorage.swift
@@ -299,38 +299,80 @@ struct DiskStorage: Sendable {
         )
     }
 
+    /// - Parameter knownUsage: A caller-tracked estimate of current disk usage, used only to
+    /// decide whether `freeSpace` can skip its directory rescan below. See that method's doc
+    /// for the safety argument — passing a stale or absent estimate never risks correctness,
+    /// only an avoidable rescan.
+    /// - Returns: The buffer to write through, and disk usage immediately after this write
+    /// (`nil` when the write didn't happen, e.g. the entry doesn't fit at all), for the caller
+    /// to keep as its next `knownUsage`.
     func allocateBuffer(
         key: String,
         cachedResponse: CachedResponse,
         contentLength: Int64,
-        maximumCapacity: Int64
-    ) async -> Internals.AnyBuffer? {
-        guard let response = try? JSONEncoder().encode(cachedResponse) else { return nil }
+        maximumCapacity: Int64,
+        knownUsage: Int64? = nil
+    ) async -> (buffer: Internals.AnyBuffer?, usage: Int64?) {
+        guard let response = try? JSONEncoder().encode(cachedResponse) else { return (nil, nil) }
 
         let writableBytes = Int64(response.count) + contentLength
-        guard writableBytes <= maximumCapacity else { return nil }
+        guard writableBytes <= maximumCapacity else { return (nil, nil) }
 
-        await freeSpace(maximumCapacity - writableBytes)
+        let usageAfterEviction = await freeSpace(
+            maximumCapacity - writableBytes,
+            knownUsage: knownUsage
+        )
 
-        guard let record = await record(key, createdAt: cachedResponse.date) else { return nil }
+        guard let record = await record(key, createdAt: cachedResponse.date) else { return (nil, nil) }
 
         do {
             try await writeAndClose(response, to: record.responseURL)
         } catch {
-            return nil
+            return (nil, nil)
         }
 
-        return await Internals.FileBuffer(record.dataURL)
+        let buffer = await Internals.FileBuffer(record.dataURL)
+        return (buffer, usageAfterEviction + writableBytes)
     }
 
-    func freeSpace(_ maximumCapacity: Int64) async {
+    /// Evicts the oldest entries, if any, until usage is at or under `maximumCapacity`.
+    ///
+    /// - Parameter knownUsage: A caller-tracked usage estimate. When it already fits under
+    /// `maximumCapacity`, the directory rescan below — a full `listContents()` plus a
+    /// reachability check and a size stat *per existing entry* — is skipped outright, since
+    /// nothing would be evicted anyway. This is the difference between a single cache write
+    /// costing O(1) versus O(current entry count): the latter turns writing `n` entries into
+    /// O(n²) total filesystem operations, cheap enough to hide on a fast local disk but not on
+    /// a simulator's slower, host-bridged filesystem, where it has been the underlying cause of
+    /// `AsyncLock.Watchdog` firing on otherwise-healthy cache writes (see #271).
+    ///
+    /// Skipping is safe regardless of how accurate `knownUsage` is:
+    /// - If it undercounts (e.g. another process sharing this directory, via `suiteName`, wrote
+    ///   since it was last reconciled here), the result is a transient, bounded overshoot of
+    ///   `maximumCapacity` — never data loss or corruption — that self-corrects the next time
+    ///   this runs without a `knownUsage` that still fits, which forces the real rescan below
+    ///   and hands back a freshly reconciled total.
+    /// - If it overcounts, this just skips straight to an unnecessary-but-harmless rescan.
+    ///
+    /// A missing `knownUsage` always takes the rescan path, so a first call with no estimate
+    /// yet, or one that no longer fits, behaves exactly as before this parameter existed.
+    ///
+    /// - Returns: Usage immediately after this call — either the untouched `knownUsage` when
+    /// skipped, or the freshly measured total otherwise — for the caller to reuse as its next
+    /// `knownUsage`.
+    @discardableResult
+    func freeSpace(_ maximumCapacity: Int64, knownUsage: Int64? = nil) async -> Int64 {
+        if let knownUsage, knownUsage <= maximumCapacity {
+            return knownUsage
+        }
+
         var entries = await records()
 
         if maximumCapacity == .zero {
             for entry in entries {
                 _ = try? await Internals.fileSystem.removeItem(at: entry.url.filePath)
             }
-            return
+            return .zero
         }
 
         entries.sort { $0.date < $1.date }
@@ -352,6 +394,8 @@ struct DiskStorage: Sendable {
             )
             totalSize -= size
         }
+
+        return totalSize
     }
 
     // MARK: - Private methods

--- a/Tests/RequestDLTests/Properties/Sources/Cache/Data Cache/DataCacheTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Cache/Data Cache/DataCacheTests.swift
@@ -392,6 +392,43 @@ struct DataCacheTests {
         #expect(cached == nil)
     }
 
+    /// Regression test for #271: `DataCache.Storage` threads a disk usage estimate across
+    /// sequential writes to skip `DiskStorage.freeSpace`'s directory rescan, rather than
+    /// discovering it fresh from disk on every single write. This exercises that estimate
+    /// across several real, sequential writes through the public API — the same path
+    /// `Storage.allocateDiskBuffer` now takes — to confirm eviction still lands correctly with
+    /// the estimate in the loop, not just when `DiskStorage` is driven directly.
+    @Test
+    func cache_whenManySequentialDiskWritesExceedCapacity_shouldEvictOldestAndKeepNewest() async throws {
+        let testState = await TestState()
+        // Given
+        let dataCache = testState.dataCache
+
+        let entryLength = 10_000
+        dataCache.diskCapacity = 25_000
+        await dataCache.waitUntilIdle()
+
+        // When: five entries are written one after another, each well past what the previous
+        // writes already used, on a capacity that cannot hold more than about two at once.
+        for index in 0..<5 {
+            let cachedData = await mockCachedData(
+                url: "https://sequential-eviction.example.com/\(index)",
+                length: entryLength,
+                policy: .disk
+            )
+            await dataCache.setCachedData(cachedData, forKey: "key\(index)")
+            await dataCache.waitUntilIdle()
+        }
+
+        // Then: the oldest entry didn't survive five entries' worth of writes on a capacity
+        // sized for about two, and the most recent write — always made room for by construction
+        // — did.
+        let oldest = await dataCache.getCachedData(forKey: "key0", policy: .disk)
+        let newest = await dataCache.getCachedData(forKey: "key4", policy: .disk)
+        #expect(oldest == nil)
+        #expect(newest != nil)
+    }
+
     @Test
     func cache_whenUpdateCachedForExistingKey_shouldReplaceMetadataAndKeepBuffer() async throws {
         let testState = await TestState()

--- a/Tests/RequestDLTests/Properties/Sources/Cache/Data Cache/Models/DiskStorageTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Cache/Data Cache/Models/DiskStorageTests.swift
@@ -46,7 +46,7 @@ struct DiskStorageTests {
             // Given: a first entry, written with plenty of room. The data file has to actually
             // exist on disk for the record to be discoverable later, so a byte is written and
             // the buffer closed.
-            var firstBuffer = await storage.allocateBuffer(
+            var (firstBuffer, _) = await storage.allocateBuffer(
                 key: "k1",
                 cachedResponse: firstResponse,
                 contentLength: 0,
@@ -59,7 +59,7 @@ struct DiskStorageTests {
 
             // When: a second entry is allocated with a capacity that only has room for itself
             // plus a sliver more — not enough to also keep the first entry around.
-            var secondBuffer = await storage.allocateBuffer(
+            var (secondBuffer, _) = await storage.allocateBuffer(
                 key: "k2",
                 cachedResponse: secondResponse,
                 contentLength: 0,
@@ -72,6 +72,99 @@ struct DiskStorageTests {
             #expect(secondBuffer != nil)
             #expect(await storage["k1"] == nil)
             #expect(await storage["k2"] != nil)
+        }
+    }
+
+    @Test
+    func freeSpace_whenKnownUsageFitsUnderCapacity_shouldSkipRescanAndKeepEverything() async throws {
+        try await withTemporaryFileURL(createPath: false) { directoryURL in
+            let storage = DiskStorage(directory: directoryURL)
+            let response = makeCachedResponse(key: "k1")
+
+            // Given: a real entry that is already over whatever capacity `freeSpace` is about
+            // to be called with — a rescan would find it and evict it.
+            var (buffer, _) = await storage.allocateBuffer(
+                key: "k1",
+                cachedResponse: response,
+                contentLength: 0,
+                maximumCapacity: .max
+            )
+            await buffer?.writeData(Data([0x1]))
+            try? await buffer?.close()
+            #expect(await storage["k1"] != nil)
+
+            // When: freeing space down to zero, but with a `knownUsage` of zero — a trusted
+            // (if, here, deliberately wrong) claim that there is nothing to evict.
+            let result = await storage.freeSpace(.zero, knownUsage: .zero)
+
+            // Then: the rescan was skipped on the strength of that claim, so the over-capacity
+            // entry survives, and the call reports back exactly the `knownUsage` it was given.
+            #expect(result == .zero)
+            #expect(await storage["k1"] != nil)
+        }
+    }
+
+    @Test
+    func freeSpace_whenKnownUsageExceedsCapacity_shouldRescanAndEvict() async throws {
+        try await withTemporaryFileURL(createPath: false) { directoryURL in
+            let storage = DiskStorage(directory: directoryURL)
+            let response = makeCachedResponse(key: "k1")
+
+            var (buffer, _) = await storage.allocateBuffer(
+                key: "k1",
+                cachedResponse: response,
+                contentLength: 0,
+                maximumCapacity: .max
+            )
+            await buffer?.writeData(Data([0x1]))
+            try? await buffer?.close()
+            #expect(await storage["k1"] != nil)
+
+            // When: `knownUsage` itself already claims to be over capacity, so the shortcut
+            // cannot apply and the real rescan below has to run.
+            let result = await storage.freeSpace(.zero, knownUsage: .max)
+
+            // Then: the real scan found and evicted the entry, and reported the true resulting
+            // total — zero, since it was the only entry — rather than the stale `knownUsage`.
+            #expect(result == .zero)
+            #expect(await storage["k1"] == nil)
+        }
+    }
+
+    @Test
+    func allocateBuffer_shouldReturnUsageReflectingTheNewEntry() async throws {
+        try await withTemporaryFileURL(createPath: false) { directoryURL in
+            let storage = DiskStorage(directory: directoryURL)
+
+            let firstResponse = makeCachedResponse(key: "k1")
+            let firstResponseSize = Int64(try JSONEncoder().encode(firstResponse).count)
+
+            // Given/When: the first entry in an empty directory, so usage after it is exactly
+            // its own size.
+            let (_, firstUsage) = await storage.allocateBuffer(
+                key: "k1",
+                cachedResponse: firstResponse,
+                contentLength: 10,
+                maximumCapacity: .max
+            )
+            #expect(firstUsage == firstResponseSize + 10)
+
+            // When: a second entry is allocated reusing that reported usage as `knownUsage` —
+            // the shape `DataCache.Storage` relies on to thread the estimate across calls.
+            try? await Task.sleep(nanoseconds: 2_000_000)
+            let secondResponse = makeCachedResponse(key: "k2")
+            let secondResponseSize = Int64(try JSONEncoder().encode(secondResponse).count)
+
+            let (_, secondUsage) = await storage.allocateBuffer(
+                key: "k2",
+                cachedResponse: secondResponse,
+                contentLength: 20,
+                maximumCapacity: .max,
+                knownUsage: firstUsage
+            )
+
+            // Then: usage accumulates exactly, with no rescan needed in between.
+            #expect(secondUsage == firstResponseSize + 10 + secondResponseSize + 20)
         }
     }
 


### PR DESCRIPTION
Fixes #271.

## Summary
- `DiskStorage.freeSpace` (called by `allocateBuffer` on every single write) unconditionally rescanned the whole cache directory and stat'd every existing entry, even when the write was nowhere near capacity and nothing needed evicting. Writing `n` entries cost `O(n²)` filesystem operations total.
- `DiskStorage.freeSpace(_:knownUsage:)` and `DiskStorage.allocateBuffer(...:knownUsage:)` now accept an optional caller-tracked usage estimate. When it already fits under the target capacity, the rescan is skipped outright and the estimate is returned unchanged; otherwise (including when there's no estimate yet) it falls back to exactly today's full rescan, which also hands back a freshly reconciled total.
- `DataCache.Storage` — already deduplicated per cache directory within a process via `DataCache.Manager` — now keeps that estimate and threads it through `allocateDiskBuffer`, so sequential/concurrent writes within one process stop paying the rescan cost once the estimate is warm.

## Why this is safe for a directory shared across processes (`suiteName`)
The estimate is advisory only, never trusted for eviction correctness:
- If it **undercounts** (e.g. another process sharing this directory wrote since it was last reconciled here), the result is a transient, bounded overshoot of the configured capacity — never data loss or corruption — that self-corrects the next time a write's estimate no longer fits, which forces the real rescan and reconciles.
- If it **overcounts**, this only costs an unneeded-but-harmless rescan.
- `remove`/`removeAll`/`removeAll(since:)`/disk-capacity-shrink deliberately leave the estimate untouched — they only ever move usage down, and an estimate that predates them is at worst a harmless overcount (safe direction).

## Testing
- Added `DiskStorageTests` cases exercising the `knownUsage` contract directly: skip-when-it-fits (and that the skip is real — an over-capacity entry survives), rescan-when-it-doesn't, and that `allocateBuffer`'s returned usage accumulates exactly across calls.
- Added `DataCacheTests.cache_whenManySequentialDiskWritesExceedCapacity_shouldEvictOldestAndKeepNewest`, exercising the full `Storage.allocateDiskBuffer` path (the estimate threaded across several real, sequential public-API writes) to confirm eviction still lands correctly with the estimate in the loop.
- `swift test` (1062 tests, full suite) and `swift format lint --recursive --strict` both pass locally.
- Not yet verified whether this measurably improves the iOS/iPadOS/visionOS Simulator CI timing that motivated #271 — that needs a real CI run to confirm.

## Test plan
- [x] `swift build`
- [x] `swift test` (full suite, 1062 tests)
- [x] `swift format lint --recursive --strict Sources Tests`
- [ ] CI green on iOS/iPadOS/visionOS Simulator jobs, and materially faster `DataCacheTests`/`CachedRequestTests` wall time