### PR TITLE
Add environment-scoped default PayloadEncoder

### DIFF
--- a/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Essentials/Exploring-payload.md
+++ b/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Essentials/Exploring-payload.md
@@ -14,7 +14,7 @@ That's why RequestDL provides ``RequestDL/Payload`` and ``RequestDL/Form`` to ma
 
 > Tip: Each object has 5 initializers that standardize data configuration in a request: Data, String, URL, Codable, and JSON (also known as [String: Any]).
 
-> Tip: Need a serialization format other than JSON, such as Protobuf or MessagePack? Implement ``RequestDL/PayloadEncoder`` and pass it to `Payload(_:encoder:contentType:)`.
+> Tip: Need a serialization format other than JSON, such as Protobuf or MessagePack? Implement ``RequestDL/PayloadEncoder`` and pass it to `Payload(_:encoder:contentType:)`. Passing `encoder: nil` there defers to a default set once via ``RequestDL/Property/payloadEncoder(_:)`` on an enclosing property, instead of repeating the same encoder at every `Payload(...)` call site.
 
 ### Payload
 
@@ -70,6 +70,7 @@ Payload(userModel, contentType: .formURLEncoded)
 
 - ``RequestDL/Payload``
 - ``RequestDL/PayloadEncoder``
+- ``RequestDL/Property/payloadEncoder(_:)``
 - ``RequestDL/EncodingPayloadError``
 
 ### Using the multipart form data

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form Group/Models/FormItem.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form Group/Models/FormItem.swift
@@ -44,12 +44,16 @@ struct FormItem: Sendable {
     ///
     /// - Note: `method` is `nil` because a form part has no HTTP method of its own. Only the
     /// top level payload consults it, to decide between a query string and a body.
+    ///
+    /// - Note: `payloadEncoder` is `nil` because `Form` has no `PayloadEncoder`-based
+    /// initializer — none of its factories ever read it.
     func callAsFunction() async throws -> Output {
         let output = try await factory(
             .init(
                 method: nil,
                 charset: charset,
-                urlEncoder: urlEncoder
+                urlEncoder: urlEncoder,
+                payloadEncoder: nil
             )
         )
 

--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/EncodingPayloadError.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/EncodingPayloadError.swift
@@ -13,6 +13,10 @@ public struct EncodingPayloadError: Sendable, Error {
 
         /// The error occurred due to an invalid string encoding
         case invalidStringEncoding
+
+        /// `Payload(_:encoder:contentType:)` was called with `encoder: nil` and no default
+        /// ``PayloadEncoder`` was set via ``Property/payloadEncoder(_:)``.
+        case missingPayloadEncoder
     }
 
     /// The context of the error.

--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/PayloadEncoderEnvironmentKey.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/PayloadEncoderEnvironmentKey.swift
@@ -1,0 +1,29 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+private struct PayloadEncoderKey: RequestEnvironmentKey {
+    static var defaultValue: (any PayloadEncoder)? { nil }
+}
+
+extension RequestEnvironmentValues {
+
+    var payloadEncoder: (any PayloadEncoder)? {
+        get { self[PayloadEncoderKey.self] }
+        set { self[PayloadEncoderKey.self] = newValue }
+    }
+}
+
+extension Property {
+
+    ///
+    /// Sets a default ``PayloadEncoder`` for every `Payload(_:encoder:contentType:)` in scope
+    /// that passes `encoder: nil`.
+    ///
+    /// - Parameter encoder: The encoder to use when a `Payload` does not specify one.
+    /// - Returns: A modified property with the specified default encoder.
+    ///
+    public func payloadEncoder<Encoder: PayloadEncoder>(_ encoder: Encoder) -> some Property {
+        environment(\.payloadEncoder, encoder)
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/PayloadEncoderFactory.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/PayloadEncoderFactory.swift
@@ -12,30 +12,38 @@ struct PayloadEncoderFactory: Sendable, PayloadFactory {
 
     // MARK: - Internal properties
 
-    let encode: @Sendable () throws -> Data
-    let contentType: ContentType
+    let encode: @Sendable (any PayloadEncoder) throws -> Data
+    let explicitEncoder: (any PayloadEncoder)?
+    let contentType: ContentType?
 
     // MARK: - Inits
 
-    init<Value: Sendable, Encoder: PayloadEncoder>(
+    init<Value: Sendable>(
         _ value: Value,
-        encoder: Encoder,
+        encoder: (any PayloadEncoder)?,
         contentType: ContentType?
     ) {
-        self.encode = { try encoder.encode(value) }
-        self.contentType = contentType ?? encoder.contentType
+        self.encode = { try $0.encode(value) }
+        self.explicitEncoder = encoder
+        self.contentType = contentType
     }
 
     // MARK: - Internal methods
 
     func callAsFunction(_ input: PayloadInput) async throws -> PayloadOutput {
+        // `encoder: nil` at the `Payload` call site defers to whatever `.payloadEncoder(_:)`
+        // put in the environment. Neither present is a caller error, not a bug to work around.
+        guard let encoder = explicitEncoder ?? input.payloadEncoder else {
+            throw EncodingPayloadError(.missingPayloadEncoder)
+        }
+
         // Unlike `EncodablePayloadFactory`, there is no form-urlencoded path here: a
         // `PayloadEncoder` produces an opaque, atomic blob (Protobuf, MessagePack, ...), not a
         // JSON object whose fields could be exploded into query items.
-        let data = try encode()
+        let data = try encode(encoder)
 
         return await .init(
-            contentType: contentType,
+            contentType: contentType ?? encoder.contentType,
             source: .buffer(Internals.DataBuffer(data))
         )
     }

--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/PayloadFactory.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/PayloadFactory.swift
@@ -31,6 +31,7 @@ struct PayloadInput {
     let method: String?
     let charset: Charset
     let urlEncoder: URLEncoder
+    let payloadEncoder: (any PayloadEncoder)?
 
     func jsonObject(_ array: [Any], contentType: ContentType) throws -> PayloadOutput {
         .init(

--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/PayloadNode.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/PayloadNode.swift
@@ -10,6 +10,7 @@ struct PayloadNode: PropertyNode {
     let charset: Charset
     let urlEncoder: URLEncoder
     let chunkSize: Int?
+    let payloadEncoder: (any PayloadEncoder)?
 
     // MARK: - Internal methods
 
@@ -18,7 +19,8 @@ struct PayloadNode: PropertyNode {
         let input = PayloadInput(
             method: make.requestConfiguration.method,
             charset: charset,
-            urlEncoder: urlEncoder
+            urlEncoder: urlEncoder,
+            payloadEncoder: payloadEncoder
         )
 
         let output = try await factory(input)

--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload/Payload.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload/Payload.swift
@@ -120,15 +120,19 @@ public struct Payload: Property {
     ///
     /// Initializes a `Payload` with a value serialized through a custom ``PayloadEncoder``.
     ///
+    /// Pass `encoder: nil` to defer to the default set via ``Property/payloadEncoder(_:)`` on an
+    /// enclosing property. Resolving to no encoder at all — neither passed here nor set on the
+    /// environment — throws ``EncodingPayloadError`` with context `.missingPayloadEncoder`.
+    ///
     /// - Parameters:
     ///    - value: The value to be serialized.
-    ///    - encoder: The encoder used to serialize `value`.
+    ///    - encoder: The encoder used to serialize `value`, or `nil` to use the environment's.
     ///    - contentType: The content type of the payload. Defaults to the encoder's own
     ///      ``PayloadEncoder/contentType``.
     ///
-    public init<Value: Sendable, Encoder: PayloadEncoder>(
+    public init<Value: Sendable>(
         _ value: Value,
-        encoder: Encoder,
+        encoder: (any PayloadEncoder)?,
         contentType: ContentType? = nil
     ) {
         factory = PayloadEncoderFactory(
@@ -234,7 +238,8 @@ public struct Payload: Property {
                 factory: property.factory,
                 charset: inputs.environment.charset,
                 urlEncoder: inputs.environment.urlEncoder,
-                chunkSize: inputs.environment.payloadChunkSize
+                chunkSize: inputs.environment.payloadChunkSize,
+                payloadEncoder: inputs.environment.payloadEncoder
             )
         )
     }

--- a/Tests/RequestDLTests/Properties/Sources/Payloads/Payload/PayloadTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Payloads/Payload/PayloadTests.swift
@@ -320,6 +320,82 @@ struct PayloadTests {
     }
 
     @Test
+    func payload_whenPayloadEncoderIsNil_usesEnvironmentDefault() async throws {
+        // Given
+        let verbatim = "Hello world!"
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Payload(
+                    verbatim,
+                    encoder: nil
+                )
+                .payloadEncoder(PayloadEncoderMock())
+            }
+        )
+
+        let data = try await resolved.requestConfiguration.body?.data()
+
+        // Then
+        #expect(
+            resolved.requestConfiguration.headers["Content-Type"] == ["application/x-mock"]
+        )
+
+        #expect(data == Data(verbatim.utf8))
+    }
+
+    @Test
+    func payload_whenPayloadEncoderIsExplicit_overridesEnvironmentDefault() async throws {
+        // Given
+        let verbatim = "Hello world!"
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Payload(
+                    verbatim,
+                    encoder: PayloadEncoderMock(contentType: "application/x-explicit")
+                )
+                .payloadEncoder(PayloadEncoderMock(contentType: "application/x-environment"))
+            }
+        )
+
+        let data = try await resolved.requestConfiguration.body?.data()
+
+        // Then
+        // The encoder passed directly to `Payload` wins over `.payloadEncoder(_:)`.
+        #expect(
+            resolved.requestConfiguration.headers["Content-Type"] == ["application/x-explicit"]
+        )
+
+        #expect(data == Data(verbatim.utf8))
+    }
+
+    @Test
+    func payload_whenPayloadEncoderIsNilAndNoEnvironmentDefault_throwsMissingPayloadEncoder() async throws {
+        // Given
+        var encodingError: EncodingPayloadError?
+
+        // When
+        do {
+            _ = try await resolve(
+                TestProperty {
+                    Payload(
+                        "Hello world!",
+                        encoder: nil
+                    )
+                }
+            )
+        } catch let error as EncodingPayloadError {
+            encodingError = error
+        }
+
+        // Then
+        #expect(encodingError?.context == .missingPayloadEncoder)
+    }
+
+    @Test
     func payload_whenInitString() async throws {
         // Given
         let verbatim = "Hello world!"


### PR DESCRIPTION
## Summary

Follow-up to #196 / #265, implementing the design settled in [discussion #267](https://github.com/orgs/request-dl/discussions/267):

- `Payload(_:encoder:contentType:)` now takes `encoder` as `(any PayloadEncoder)?` (no default — `Payload(mock)` is unaffected) instead of a generic `Encoder: PayloadEncoder`. Passing `encoder: nil` defers to a default set once via the new `.payloadEncoder(_:)` environment modifier, resolved the same place `charset`/`urlEncoder` already are (`Payload._makeProperty` → `PayloadNode` → `PayloadInput`), instead of repeating the same encoder at every `Payload(...)` call site.
- Missing both an explicit encoder and an environment default throws `EncodingPayloadError` with a new `.missingPayloadEncoder` context.
- `FormItem` (which reuses `PayloadInput`) passes `payloadEncoder: nil` — `Form` has no `PayloadEncoder`-based initializer, so none of its factories ever read it.
- Docc guide and topics updated.

Design note kept from the discussion: `encoder` stays **required-but-nilable**, not `= nil`-defaulted, specifically so it can't collide with the existing `Payload(_:encoder:contentType:)` for `Encodable` — `Payload(mock)` keeps resolving to the `JSONEncoder` initializer unchanged, since `nil` isn't a valid `JSONEncoder`.

Ref: https://github.com/orgs/request-dl/discussions/267

## Test plan

- [x] `swift build`
- [x] `swift test` — 1090 tests, 169 suites, all passing
- [x] `swift format lint --recursive --strict Sources Tests`
- [x] New unit tests: environment fallback (`encoder: nil` + `.payloadEncoder(_:)`), explicit encoder overriding the environment default, and the `.missingPayloadEncoder` error when neither is set