### PR TITLE
Curate public error/property types missing from DocC Topics

### DIFF
--- a/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Essentials/Creating-requests-from-scratch.md
+++ b/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Essentials/Creating-requests-from-scratch.md
@@ -213,7 +213,10 @@ Learn more in:
 
 - ``RequestDL/Session``
 - ``RequestDL/Proxy``
+- ``RequestDL/SystemProxy``
 - ``RequestDL/DNSOverride``
+- ``RequestDL/URLOverride``
+- ``RequestDL/URLOverrideError``
 
 ### Adding request timeout
 

--- a/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Essentials/Exploring-payload.md
+++ b/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Essentials/Exploring-payload.md
@@ -71,6 +71,8 @@ Payload(userModel, contentType: .formURLEncoded)
 - ``RequestDL/Payload``
 - ``RequestDL/PayloadEncoder``
 - ``RequestDL/EncodingPayloadError``
+- ``RequestDL/FilePayloadError``
+- ``RequestDL/InvalidPayloadOffsetError``
 
 ### Using the multipart form data
 

--- a/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Making your request secure/Secure-connection.md
+++ b/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Making your request secure/Secure-connection.md
@@ -107,6 +107,7 @@ This rule is necessary to avoid the instantiation of new clients provided by `As
 ### The basics about certificates
 
 - ``RequestDL/Certificate``
+- ``RequestDL/SecureFileError``
 
 ### Configuring the server trust
 

--- a/Sources/RequestDL/Documentation.docc/Essentials/Executing the Request/For Everybody/Swift-concurrency.md
+++ b/Sources/RequestDL/Documentation.docc/Essentials/Executing the Request/For Everybody/Swift-concurrency.md
@@ -62,6 +62,7 @@ In addition, each received element is inserted into a queue that remains availab
 
 - ``RequestDL/AsyncResponse``
 - ``RequestDL/AsyncBytes``
+- ``RequestDL/AlreadyConsumedError``
 
 ### Thread locks
 


### PR DESCRIPTION
## Summary
- `AlreadyConsumedError`, `SystemProxy`, `FilePayloadError`, `InvalidPayloadOffsetError`, `SecureFileError`, `URLOverride`, and `URLOverrideError` are public API but weren't referenced from any `## Topics` section, so DocC generated orphan pages for them instead of curating them into the guides.
- Added each to the Topics section of the article covering its closest sibling type: `AlreadyConsumedError` next to `AsyncResponse`/`AsyncBytes`, `SystemProxy`/`URLOverride`/`URLOverrideError` next to `Proxy`/`DNSOverride`, `FilePayloadError`/`InvalidPayloadOffsetError` next to `Payload`, and `SecureFileError` next to `Certificate`.

## Test plan
- [x] Docs-only change; no code or behavior touched.