### PR TITLE
Add Session.compression(_:) for request-body compression

### DIFF
--- a/Sources/RequestDL/Internals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
+++ b/Sources/RequestDL/Internals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
@@ -3,6 +3,9 @@
 //
 
 import AsyncHTTPClient
+import NIOCore
+import NIOHTTP1
+import NIOHTTPCompression
 
 extension Internals.Session {
 
@@ -17,6 +20,7 @@ extension Internals.Session {
         var proxy: Internals.Proxy?
         var ignoreUncleanSSLShutdown: Bool = false
         var decompression: Internals.Decompression = .disabled
+        var compression: Internals.Compression = .disabled
         var dnsOverride: [String: String] = [:]
         var networkFrameworkWaitForConnectivity: Bool?
         var httpVersion: Internals.HTTPVersion?
@@ -47,6 +51,26 @@ extension Internals.Session {
 
             if let httpVersion {
                 configuration.httpVersion = httpVersion.build()
+            }
+
+            if case .enabled(let algorithm) = compression {
+                let encoding = algorithm.build()
+
+                // `NIOHTTPRequestCompressor` is deliberately not `Sendable` (mutable per-connection
+                // compression state), so it can only be added via the synchronous pipeline API, which
+                // requires running on the channel's own event loop. AsyncHTTPClient doesn't guarantee
+                // this debug initializer runs there, hence the explicit `submit`.
+                configuration.http1_1ConnectionDebugInitializer = { channel in
+                    channel.eventLoop.submit {
+                        let sync = channel.pipeline.syncOperations
+                        let requestEncoderContext = try sync.context(handlerType: HTTPRequestEncoder.self)
+
+                        try sync.addHandler(
+                            NIOHTTPRequestCompressor(encoding: encoding),
+                            position: .after(requestEncoderContext.handler)
+                        )
+                    }
+                }
             }
 
             return configuration

--- a/Sources/RequestDL/Internals/Sources/Session/Session Configuration/Models/Internals.Compression.swift
+++ b/Sources/RequestDL/Internals/Sources/Session/Session Configuration/Models/Internals.Compression.swift
@@ -1,0 +1,34 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import NIOHTTPCompression
+
+extension Internals {
+
+    enum Compression: Sendable, Hashable {
+
+        case disabled
+        case enabled(Internals.Compression.Algorithm)
+    }
+}
+
+extension Internals.Compression {
+
+    enum Algorithm: Sendable, Hashable {
+
+        case gzip
+        case deflate
+
+        // MARK: - Internal methods
+
+        func build() -> NIOCompression.Algorithm {
+            switch self {
+            case .gzip:
+                return .gzip
+            case .deflate:
+                return .deflate
+            }
+        }
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Session/Session/Models/Session.CompressionAlgorithm.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Session/Models/Session.CompressionAlgorithm.swift
@@ -1,0 +1,24 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+extension Session {
+
+    /// The algorithm used to compress the outgoing request body.
+    public enum CompressionAlgorithm: Sendable, Hashable {
+
+        case gzip
+        case deflate
+
+        // MARK: - Internal methods
+
+        func build() -> Internals.Compression.Algorithm {
+            switch self {
+            case .gzip:
+                return .gzip
+            case .deflate:
+                return .deflate
+            }
+        }
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Session/Session/Session.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Session/Session.swift
@@ -161,6 +161,20 @@ public struct Session: Property {
         edit { $0.decompression = .enabled(decompressionLimit.build()) }
     }
 
+    ///
+    /// Compresses the outgoing request body before it's sent over the wire, setting the
+    /// `Content-Encoding` header accordingly.
+    ///
+    /// This is independent of which `Payload` source produced the body (`Data`/`JSON`/`String`/
+    /// `File`/`Form`) and only applies to connections negotiated as HTTP/1.1.
+    ///
+    /// - Parameter algorithm: The algorithm used to compress the request body.
+    /// - Returns: The modified `Session` instance with request-body compression configured.
+    ///
+    public func compression(_ algorithm: CompressionAlgorithm) -> Self {
+        edit { $0.compression = .enabled(algorithm.build()) }
+    }
+
     // MARK: - Private properties
 
     private func edit(

--- a/Tests/RequestDLTests/Internals/Sources/Session/Session/InternalsSessionTests.swift
+++ b/Tests/RequestDLTests/Internals/Sources/Session/Session/InternalsSessionTests.swift
@@ -261,4 +261,69 @@ struct InternalsSessionTests {
                 )
         )
     }
+
+    @Test
+    func session_whenCompressionEnabled_shouldSendCompressedBody() async throws {
+        let testState = try await TestState()
+        // Given
+        let localServer = testState.localServer
+        let testingSession = testState.session
+
+        let certificates = Certificates().server()
+        let message = "Hello World"
+
+        // Highly-compressible: a single repeated byte, so gzip shrinks it drastically.
+        let payload = Data(String(repeating: "a", count: 100_000).utf8)
+
+        let response = try LocalServer.ResponseConfiguration(
+            jsonObject: message
+        )
+
+        localServer.insert(response, at: testState.uri)
+
+        // When
+        var requestConfiguration = RequestConfiguration()
+        requestConfiguration.baseURL = "https://\(localServer.baseURL)"
+        requestConfiguration.pathComponents = [testState.uri.trimmingCharacters(in: .init(charactersIn: "/"))]
+        requestConfiguration.method = "POST"
+        requestConfiguration.body = await RequestBody(buffers: [Internals.DataBuffer(payload)])
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.trustRoots = .certificates([
+            .init(certificates.certificateURL.absolutePath(percentEncoded: false), format: .pem)
+        ])
+
+        var configuration = testingSession.configuration
+        configuration.secureConnection = secureConnection
+        configuration.compression = .enabled(.gzip)
+
+        let session = Internals.Session(
+            provider: testingSession.provider,
+            configuration: configuration
+        )
+
+        let task = try await session.execute(
+            requestConfiguration: requestConfiguration,
+            dataCache: .init(),
+            logger: nil
+        )
+
+        var download: (ResponseHead, Data)?
+
+        for try await result in task() {
+            if case .download(let step) = result {
+                download = (step.head, try await Data(Array(step.bytes).joined()))
+            }
+        }
+
+        // Then
+        let result = try (download?.1).map(HTTPResult<String>.init)
+
+        #expect(result?.response == message)
+
+        // The server only ever sees the wire bytes it read, so a `receivedBytes` well below the
+        // original payload size is proof the request body actually went out gzip-compressed.
+        let receivedBytes = try #require(result?.receivedBytes)
+        #expect(receivedBytes < payload.count / 2)
+    }
 }

--- a/Tests/RequestDLTests/Properties/Sources/Session/Session/SessionTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Session/Session/SessionTests.swift
@@ -221,6 +221,46 @@ struct SessionTests {
     }
 
     @Test
+    func session_whenCompressionDefault_shouldBeDisabled() async throws {
+        // Given
+        let property = Session()
+
+        // When
+        let resolved = try await resolve(TestProperty { property })
+
+        // Then
+        #expect(resolved.session.configuration.compression == .disabled)
+    }
+
+    @Test
+    func session_whenCompressionGzip_shouldBeValid() async throws {
+        // Given
+        let algorithm = Session.CompressionAlgorithm.gzip
+        let property = Session()
+            .compression(algorithm)
+
+        // When
+        let resolved = try await resolve(TestProperty { property })
+
+        // Then
+        #expect(resolved.session.configuration.compression == .enabled(algorithm.build()))
+    }
+
+    @Test
+    func session_whenCompressionDeflate_shouldBeValid() async throws {
+        // Given
+        let algorithm = Session.CompressionAlgorithm.deflate
+        let property = Session()
+            .compression(algorithm)
+
+        // When
+        let resolved = try await resolve(TestProperty { property })
+
+        // Then
+        #expect(resolved.session.configuration.compression == .enabled(algorithm.build()))
+    }
+
+    @Test
     func session_whenNeverBody_shouldBeNever() async throws {
         // Given
         let property = Session()


### PR DESCRIPTION
## Summary
- Adds `Session.compression(_:)` (gzip/deflate) to compress the outgoing request body, setting `Content-Encoding` automatically — mirrors the existing `decompressionLimit(_:)` shape.
- Distinct from the existing `Session.disableDecompression()`/`decompressionLimit(_:)`, which only handle **response** decompression (already provided natively by AsyncHTTPClient).
- Backed by `NIOHTTPRequestCompressor` from `swift-nio-extras` (already a transitive dependency). AsyncHTTPClient has no official hook for outbound compression, so this wires the compressor into the HTTP/1.1 connection pipeline via the public `http1_1ConnectionDebugInitializer`, inserted right after `HTTPRequestEncoder` once the pipeline exists. Only applies to HTTP/1.1 connections (HTTP/2 uses different framing and never invokes this hook).
- Operates at the session/channel level on the final serialized request body, independent of which `Payload` source produced it.

Closes #198

## Test plan
- [x] `swift build`
- [x] `swift test` — full suite (1093 tests) passes
- [x] `swift format lint --recursive --strict Sources Tests`
- [x] Unit tests in `SessionTests.swift` covering the `Session.compression(_:)` → `Internals.Session.Configuration.compression` wiring (default `.disabled`, `.gzip`, `.deflate`)
- [x] New end-to-end test in `InternalsSessionTests.swift` (`session_whenCompressionEnabled_shouldSendCompressedBody`) that spins up the real `LocalServer`, sends a 100,000-byte highly-compressible payload with compression enabled, and asserts the server actually received under half the original bytes — proof compression happens on the wire, not just that a flag was set

🤖 Generated with [Claude Code](https://claude.com/claude-code)