### PR TITLE
Fix DocC build warnings

### DIFF
--- a/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Essentials/Creating-requests-from-scratch.md
+++ b/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Essentials/Creating-requests-from-scratch.md
@@ -163,7 +163,6 @@ Learn more in:
 
 - ``RequestDL/BaseURL``
 - ``RequestDL/URLScheme``
-- ``RequestDL/InternetProtocol``
 - ``RequestDL/BaseURLError``
 - ``RequestDL/FlexibleURL``
 - ``RequestDL/FlexibleURLError``

--- a/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Essentials/Exploring-payload.md
+++ b/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Essentials/Exploring-payload.md
@@ -99,7 +99,6 @@ Payload(userModel, contentType: .formURLEncoded)
 ### Configure how the data will be uploaded
 
 - ``RequestDL/Property/payloadChunkSize(_:)``
-- ``RequestDL/Property/payloadPartLength(_:)``
 
 ### Setting up the download strategy
 

--- a/Sources/RequestDL/Documentation.docc/Essentials/Executing the Request/For Everybody/Exploring-task.md
+++ b/Sources/RequestDL/Documentation.docc/Essentials/Executing the Request/For Everybody/Exploring-task.md
@@ -140,7 +140,7 @@ let result = try await MockedTask(
 print(result.payload)
 ```
 
-> Tip: ``RequestDL/MockedTask`` returns an ``RequestDL/AsyncResponse``, just like ``RequestDL/UploadTask``. Use ``RequestDL/RequestTask/collectData()`` to collapse it into a ``RequestDL/TaskResult`` the same way ``RequestDL/DataTask`` does.
+> Tip: ``RequestDL/MockedTask`` returns an ``RequestDL/AsyncResponse``, just like ``RequestDL/UploadTask``. Use ``RequestDL/RequestTask/collectData()-3viv5`` to collapse it into a ``RequestDL/TaskResult`` the same way ``RequestDL/DataTask`` does.
 
 Use the `headers` parameter to overlay something that is not part of the request itself — it takes precedence over a mirrored header with the same name. Use `delay` to simulate network latency, and ``RequestDL/MockedTask/init(throwing:delay:)`` to simulate a transport-level failure instead of a response:
 

--- a/Sources/RequestDL/Documentation.docc/Essentials/Executing the Request/For Everybody/Swift-concurrency.md
+++ b/Sources/RequestDL/Documentation.docc/Essentials/Executing the Request/For Everybody/Swift-concurrency.md
@@ -63,8 +63,3 @@ In addition, each received element is inserted into a queue that remains availab
 - ``RequestDL/AsyncResponse``
 - ``RequestDL/AsyncBytes``
 - ``RequestDL/AlreadyConsumedError``
-
-### Thread locks
-
-- ``RequestDL/AsyncLock``
-- ``RequestDL/AsyncSignal``

--- a/Sources/RequestDL/Documentation.docc/Essentials/Executing the Request/Monitoring Upload and Download Progress/Upload-and-download-progress.md
+++ b/Sources/RequestDL/Documentation.docc/Essentials/Executing the Request/Monitoring Upload and Download Progress/Upload-and-download-progress.md
@@ -62,6 +62,5 @@ print(result.payload)
 ### Discover the modifiers
 
 - ``RequestDL/Modifiers/Progress``
-- ``RequestDL/Modifiers/IgnoresProgress``
 - ``RequestDL/Modifiers/CollectBytes``
 - ``RequestDL/Modifiers/CollectData``

--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload/Payload.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload/Payload.swift
@@ -51,7 +51,7 @@ import class Foundation.JSONSerialization
 ///
 /// ### Sending Encodable
 ///
-/// - ``RequestDL/Payload/init(_:encoder:contentType:)``
+/// - ``RequestDL/Payload/init(_:encoder:contentType:)-(Object,_,_)``
 ///
 /// ### Sending values through a custom encoder
 ///

--- a/Sources/RequestDL/Properties/Sources/Value/Stored Object/StoredObject.swift
+++ b/Sources/RequestDL/Properties/Sources/Value/Stored Object/StoredObject.swift
@@ -62,7 +62,7 @@ public struct StoredObject<Object: AnyObject & Sendable>: DynamicValue {
     ///
     /// Initializes a new `StoredObject` with the given object.
     ///
-    /// - Parameter wrappedValue: The object that will be stored in memory.
+    /// - Parameter thunk: The object that will be stored in memory.
     ///
     public init(wrappedValue thunk: @autoclosure @escaping @Sendable () -> Object) {
         self.thunk = thunk

--- a/Sources/RequestDL/Tasks/Extensions/Task+Methods.swift
+++ b/Sources/RequestDL/Tasks/Extensions/Task+Methods.swift
@@ -23,8 +23,6 @@ extension RequestTask {
     ///
     /// - Throws: An error if any ping request fails (i.e., if the underlying `result()` call throws).
     ///
-    /// - Returns: `Void`. This method does not return data—it only ensures the request completes successfully.
-    ///
     public func ping(_ times: Int = 1, logger: Logger? = nil) async throws {
         if times <= 0 {
             return

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Modifiers.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Modifiers.swift
@@ -44,8 +44,6 @@
 /// - ``RequestDL/RequestEnvironmentKey``
 /// - ``RequestDL/RequestEnvironmentValues``
 /// - ``RequestDL/Modifiers/Environment``
-/// - ``RequestDL/TaskEnvironmentKey``
-/// - ``RequestDL/TaskEnvironmentValues``
 ///
 /// ### Erasing the task type
 ///

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/Mocked/MockedTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/Mocked/MockedTask.swift
@@ -6,12 +6,12 @@
 /// network call.
 ///
 /// The `content` block is a request description just like any other task's — ``RequestDL/BaseURL``,
-/// ``RequestDL/Headers``, ``RequestDL/AcceptHeader``, ``RequestDL/Authorization``,
+/// ``RequestDL/HeaderGroup``, ``RequestDL/AcceptHeader``, ``RequestDL/Authorization``,
 /// ``RequestDL/Payload``, and so on. Resolving it produces the mocked response: every header the
 /// request would carry (including `Content-Type`/`Content-Length` from ``RequestDL/Payload``) is
 /// copied onto the response, and ``RequestDL/Payload``'s bytes become the response body. That makes
 /// `MockedTask` a way to inspect exactly what a request would look like — URL, headers, encoded body
-/// — by running it through the same result-processing pipeline (``RequestDL/RequestTask/collectData()``,
+/// — by running it through the same result-processing pipeline (``RequestDL/RequestTask/collectData()-3viv5``,
 /// modifiers, `.decode(_:)`, ...) a real task would use, without a live server.
 ///
 /// ```swift


### PR DESCRIPTION
## Summary
- Disambiguate DocC links to overloaded symbols (`Payload.init(_:encoder:contentType:)`, `RequestTask.collectData()`) using DocC's hash-based disambiguators, resolved by running `xcodebuild docbuild` against a generated `.doccarchive`.
- Drop or update Topics links to symbols that no longer exist (`InternetProtocol`, `TaskEnvironmentKey`/`TaskEnvironmentValues`, `AsyncLock`/`AsyncSignal`, `IgnoresProgress`, `payloadPartLength(_:)`, `Headers`) — each one traced back to a rename/removal commit (e.g. the 4.0 async/concurrency rewrite) to confirm the correct replacement or that the entry should simply be removed.
- Fix two doc-comment mismatches: a `- Returns:` tag on a `Void`-returning method, and an `- Parameter` using the external label (`wrappedValue`) instead of the internal one (`thunk`).

## Test plan
- [x] `xcodebuild docbuild -scheme request-dl -destination 'platform=macOS'` — zero DocC warnings remain in the `RequestDL` target (only an unrelated, pre-existing Sendable compiler warning in `PublishedTask.swift` remains, out of scope for this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)