### PR TITLE
ci: enable Android cross-compile build step

### DIFF
--- a/.github/workflows/swift-ci.yaml
+++ b/.github/workflows/swift-ci.yaml
@@ -61,6 +61,9 @@ jobs:
       # Step 3 – Linkage Test (renomeado de test-foundation-essentials)
       enable-linkage-test: true
 
+      # Step 3 – Android Build
+      enable-android-build: true
+
       # Step 4
       enable-coverage-upload: true
     secrets: inherit

--- a/.github/workflows/swift-ci.yaml
+++ b/.github/workflows/swift-ci.yaml
@@ -31,7 +31,11 @@ concurrency:
 jobs:
   ci:
     name: "Swift CI"
-    uses: request-dl/.github/.github/workflows/swift-ci.yaml@main
+    # TEMP: pointed at the .github Android-build fix branch instead of @main
+    # while request-dl/.github#94 is still in flight, so we can iterate on
+    # android-build failures without merging to .github's main each time.
+    # Revert to @main once #94 merges.
+    uses: request-dl/.github/.github/workflows/swift-ci.yaml@ci/android-sdk-fix
     with:
       name: request-dl
       product-name: RequestDL

--- a/.github/workflows/swift-ci.yaml
+++ b/.github/workflows/swift-ci.yaml
@@ -31,11 +31,7 @@ concurrency:
 jobs:
   ci:
     name: "Swift CI"
-    # TEMP: pointed at the .github Android-build fix branch instead of @main
-    # while request-dl/.github#94 is still in flight, so we can iterate on
-    # android-build failures without merging to .github's main each time.
-    # Revert to @main once #94 merges.
-    uses: request-dl/.github/.github/workflows/swift-ci.yaml@ci/android-sdk-fix
+    uses: request-dl/.github/.github/workflows/swift-ci.yaml@main
     with:
       name: request-dl
       product-name: RequestDL

--- a/Sources/RequestDL/Internals/Extensions/Override/Internals.Override.Raise.swift
+++ b/Sources/RequestDL/Internals/Extensions/Override/Internals.Override.Raise.swift
@@ -4,6 +4,8 @@
 
 #if canImport(Darwin)
 import Darwin
+#elseif canImport(Android)
+@preconcurrency import Android
 #elseif canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)
@@ -67,6 +69,8 @@ extension Internals.Override {
     fileprivate static func systemRaise(_ value: Int32) -> Int32 {
         #if canImport(Darwin)
         return Darwin.raise(value)
+        #elseif canImport(Android)
+        return Android.raise(value)
         #elseif canImport(Glibc)
         return Glibc.raise(value)
         #elseif canImport(Musl)


### PR DESCRIPTION
## Summary
- Opts into the new `android-build` job from the shared `swift-ci.yaml` reusable workflow (request-dl/.github#93) by setting `enable-android-build: true`.
- Cross-compiles RequestDL for Android (`aarch64-unknown-linux-android28`) on every push/PR to `main`, build-only.

## Dependency
This calls `uses: request-dl/.github/.github/workflows/swift-ci.yaml@main`, so CI on this PR won't pick up the new `android-build` job (and may fail on the unrecognized `enable-android-build` input) until request-dl/.github#93 is merged to `main` first.

## Test plan
- [ ] Merge request-dl/.github#93 first
- [ ] Confirm `android-build` job runs and passes in this PR's CI