### PR TITLE
ci: validate SwiftPM dependency cache (temporary, do not merge)

### DIFF
--- a/.github/workflows/swift-ci.yaml
+++ b/.github/workflows/swift-ci.yaml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   ci:
     name: "Swift CI"
-    uses: request-dl/.github/.github/workflows/swift-ci.yaml@main
+    uses: request-dl/.github/.github/workflows/swift-ci.yaml@ci/cache-swiftpm-dependencies
     with:
       name: request-dl
       product-name: RequestDL


### PR DESCRIPTION
## Summary
- Temporarily points this repo's `swift-ci.yaml` at `request-dl/.github/.github/workflows/swift-ci.yaml@ci/cache-swiftpm-dependencies` instead of `@main`, to exercise [request-dl/.github#95](https://github.com/request-dl/.github/pull/95) (shared SwiftPM dependency-checkout cache) across this repo's full CI matrix before that PR merges.

**Do not merge this PR.** Once `.github#95` merges, close this without merging — the ref pin here is only for validation.

## Test plan
- [ ] Confirm all 9 CI legs (7 Apple destinations, Linux, Android) still pass with the cache-enabled workflow.
- [ ] Re-run the workflow a second time and confirm the `📦 Cache SwiftPM Dependencies` step reports a cache hit in each job.
- [ ] Confirm `apple-tests` builds correctly with `-clonedSourcePackagesDirPath .swiftpm-cache` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)