### PR TITLE
Add Session.maximumConcurrentConnections(_:) to cap in-flight requests

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Session/Session/Session.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Session/Session.swift
@@ -123,6 +123,21 @@ public struct Session: Property {
     }
 
     ///
+    /// Caps how many requests made through this session may be in flight at once, across every
+    /// host, from the moment a request is asked to execute until it completes.
+    ///
+    /// Unlike ``maximumConnectionsPerHost(_:)``, which is a per-host soft limit that AsyncHTTPClient
+    /// may exceed, this is an exact, session-wide cap: once it is reached, further requests wait
+    /// in line for a slot to free up rather than opening another connection.
+    ///
+    /// - Parameter maximum: The maximum number of requests this session may have in flight at once.
+    /// - Returns: The modified `Session` instance with the concurrency limit configured.
+    ///
+    public func maximumConcurrentConnections(_ maximum: Int) -> Self {
+        edit { $0.maximumConcurrentConnections = maximum }
+    }
+
+    ///
     /// Disables redirect for the session.
     ///
     /// - Returns: The modified `Session` instance with redirect disabled.

--- a/Sources/RequestDLInternals/Sources/Client/Client Manager/Internals.ClientManager.swift
+++ b/Sources/RequestDLInternals/Sources/Client/Client Manager/Internals.ClientManager.swift
@@ -217,7 +217,8 @@ extension Internals {
         ) throws -> Internals.Client {
             let client = Internals.Client(
                 eventLoopGroupProvider: .shared(eventLoopGroup),
-                configuration: try sessionConfiguration.build()
+                configuration: try sessionConfiguration.build(),
+                maximumConcurrentConnections: sessionConfiguration.maximumConcurrentConnections
             )
 
             tableLock.withLock {

--- a/Sources/RequestDLInternals/Sources/Client/Client/Internals.Client.swift
+++ b/Sources/RequestDLInternals/Sources/Client/Client/Internals.Client.swift
@@ -48,6 +48,11 @@ extension Internals {
         private let manager = Internals.ClientOperationQueue()
         private let _client: HTTPClient
 
+        /// Caps how many requests this client may have in flight at once, from the moment a
+        /// request is asked to execute until it completes, is cancelled, or is released.
+        /// `nil` when the session was not configured with a limit, leaving requests unthrottled.
+        private let connectionSemaphore: AsyncSemaphore?
+
         // MARK: - Unsafe properties
 
         private var _isClosed: Bool
@@ -56,13 +61,15 @@ extension Internals {
 
         package init(
             eventLoopGroupProvider: HTTPClient.EventLoopGroupProvider,
-            configuration: HTTPClient.Configuration
+            configuration: HTTPClient.Configuration,
+            maximumConcurrentConnections: Int? = nil
         ) {
             _isClosed = false
             _client = .init(
                 eventLoopGroupProvider: eventLoopGroupProvider,
                 configuration: configuration
             )
+            connectionSemaphore = maximumConcurrentConnections.map { .init(permits: $0) }
         }
 
         deinit {
@@ -86,8 +93,8 @@ extension Internals {
         package func execute(
             request: HTTPClient.Request,
             logger: TaskLogger?
-        ) -> UnsafeTask<ResponseAccumulator.Response> {
-            execute(
+        ) async -> UnsafeTask<ResponseAccumulator.Response> {
+            await execute(
                 request: request,
                 delegate: ResponseAccumulator(request: request),
                 logger: logger
@@ -98,7 +105,11 @@ extension Internals {
             request: HTTPClient.Request,
             delegate: Delegate,
             logger: TaskLogger?
-        ) -> UnsafeTask<Delegate.Response> {
+        ) async -> UnsafeTask<Delegate.Response> {
+            // Waited on before anything else, so a session configured with a limit never opens
+            // more connections than that, whether or not one is free to reuse.
+            await connectionSemaphore?.wait()
+
             // Registered before the request goes out, so the client counts as busy from the
             // moment it is asked to do anything.
             let operation = manager.operation()
@@ -118,11 +129,14 @@ extension Internals {
                 )
             }
 
+            let connectionSemaphore = self.connectionSemaphore
+
             return UnsafeTask(task) {
                 // No lock and no task hop. Completing an operation is a counter decrement now,
                 // so wrapping it in `AsyncLock` only bought a suspension on a path that can be
                 // reached from an event loop.
                 operation.complete()
+                connectionSemaphore?.signal()
             }
         }
 

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
@@ -25,6 +25,7 @@ extension Internals.Session {
         package var networkFrameworkWaitForConnectivity: Bool?
         package var httpVersion: Internals.HTTPVersion?
         package var enableNetworkFramework: Bool = false
+        package var maximumConcurrentConnections: Int?
 
         // MARK: - Inits
 

--- a/Sources/RequestDLInternals/Sources/Session/Session/Internals.Session.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session/Internals.Session.swift
@@ -69,7 +69,7 @@ extension Internals {
                 download: download.stream
             )
 
-            let unsafeTask = client.execute(
+            let unsafeTask = await client.execute(
                 request: request,
                 delegate: delegate,
                 logger: logger

--- a/Tests/RequestDLInternalsTests/Sources/Client/Client/InternalsClientConcurrencyLimitTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/Client/InternalsClientConcurrencyLimitTests.swift
@@ -1,0 +1,71 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import AsyncHTTPClient
+import NIOCore
+import NIOPosix
+import Testing
+
+@testable import RequestDLInternals
+
+struct InternalsClientConcurrencyLimitTests {
+
+    @Test
+    func execute_whenMaximumConcurrentConnectionsSet_limitsInFlightRequests() async throws {
+        try await withHangingServer { port in
+            let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
+            let client = Internals.Client(
+                eventLoopGroupProvider: .shared(group),
+                configuration: .init(),
+                maximumConcurrentConnections: 2
+            )
+
+            let startedCounter = StartedCounter()
+            let requestCount = 5
+
+            try await withThrowingTaskGroup(of: Void.self) { taskGroup in
+                for _ in 0..<requestCount {
+                    taskGroup.addTask {
+                        let request = try HTTPClient.Request(url: "http://127.0.0.1:\(port)/")
+                        let task = await client.execute(request: request, logger: nil)
+                        await startedCounter.increment()
+
+                        // Holds the permit long enough for the assertion below to observe it,
+                        // then releases it the same way `InternalsUnsafeTaskTests` does: cancel
+                        // the awaiting task, which drives `UnsafeTask`'s cancel path and, with
+                        // it, the semaphore signal.
+                        let responseTask = _Concurrency.Task { try? await task.response() }
+                        try? await _Concurrency.Task.sleep(nanoseconds: 400_000_000)
+                        responseTask.cancel()
+                        _ = await responseTask.value
+                    }
+                }
+
+                // Long enough for the first wave to acquire its permits, short enough that the
+                // second wave — gated behind the 400ms hold above — has not started yet.
+                try await _Concurrency.Task.sleep(nanoseconds: 150_000_000)
+
+                // Then: only as many requests as the configured limit have actually reached
+                // `_client.execute`; the rest are still suspended on the semaphore.
+                #expect(await startedCounter.value == 2)
+
+                try await taskGroup.waitForAll()
+            }
+
+            // Then: every request eventually got its turn once earlier ones released theirs.
+            #expect(await startedCounter.value == requestCount)
+
+            _ = try? await client.shutdown()
+            try await group.shutdownGracefully()
+        }
+    }
+}
+
+private actor StartedCounter {
+    private(set) var value = 0
+
+    func increment() {
+        value += 1
+    }
+}

--- a/Tests/RequestDLInternalsTests/Sources/Client/Client/Models/InternalsUnsafeTaskTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/Client/Models/InternalsUnsafeTaskTests.swift
@@ -21,7 +21,7 @@ struct InternalsUnsafeTaskTests {
             )
 
             let request = try HTTPClient.Request(url: "http://127.0.0.1:\(port)/")
-            let unsafeTask = client.execute(request: request, logger: nil)
+            let unsafeTask = await client.execute(request: request, logger: nil)
 
             let responseTask = _Concurrency.Task {
                 try await unsafeTask.response()
@@ -52,8 +52,8 @@ struct InternalsUnsafeTaskTests {
             )
 
             let request = try HTTPClient.Request(url: "http://127.0.0.1:\(port)/")
-            let first = client.execute(request: request, logger: nil)
-            let second = client.execute(request: request, logger: nil)
+            let first = await client.execute(request: request, logger: nil)
+            let second = await client.execute(request: request, logger: nil)
             let firstCopy = first
 
             // Then
@@ -78,7 +78,7 @@ struct InternalsUnsafeTaskTests {
 /// A bare TCP server that accepts a connection and never writes anything back — used to keep a
 /// request genuinely in flight so it can be cancelled mid-request, something `LocalServer`
 /// cannot do, since it always answers immediately.
-private func withHangingServer<Result>(
+func withHangingServer<Result>(
     _ body: (Int) async throws -> Result
 ) async throws -> Result {
     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -103,7 +103,7 @@ private func withHangingServer<Result>(
     }
 }
 
-private final class HangingServerHandler: ChannelInboundHandler, @unchecked Sendable {
+final class HangingServerHandler: ChannelInboundHandler, @unchecked Sendable {
 
     typealias InboundIn = ByteBuffer
 

--- a/Tests/RequestDLTests/Properties/Sources/Session/Session/SessionTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Session/Session/SessionTests.swift
@@ -107,6 +107,23 @@ struct SessionTests {
     }
 
     @Test
+    func session_whenMaxConcurrentConnections_shouldBeValid() async throws {
+        // Given
+        let maximumConcurrentConnections = 4
+
+        let property = Session()
+            .maximumConcurrentConnections(maximumConcurrentConnections)
+
+        // When
+        let resolved = try await resolve(TestProperty { property })
+
+        // Then
+        #expect(
+            resolved.session.configuration.maximumConcurrentConnections == maximumConcurrentConnections
+        )
+    }
+
+    @Test
     func session_whenDisableRedirect_shouldBeValid() async throws {
         // Given
         let property = Session()


### PR DESCRIPTION
## Summary
- Adds `Session.maximumConcurrentConnections(_:)`, a session-wide hard cap on how many requests may be in flight at once, backed by the existing `AsyncSemaphore` (from `SwiftAsyncStream`). Once the limit is reached, further requests wait in line for a slot instead of opening another connection.
- Unlike the existing `maximumConnectionsPerHost(_:)`, which only sets AsyncHTTPClient's per-host **soft** limit (documented to be exceedable via overflow connections), this is an exact, global cap shared by every request reusing the same pooled client for a given `Session` configuration.
- Motivated by a crash observed inside Apple's Network.framework (`nw_path_enumerate_interfaces` / `swift_unknownObjectRetain`) when many `NIOTransportServices` connections activate concurrently — capping concurrent connection setups reduces exposure to that race.

## Implementation
- `Internals.Client` now takes an optional `maximumConcurrentConnections: Int?` and gates `execute(...)` on an `AsyncSemaphore` acquired before dispatching to `AsyncHTTPClient` and released in the existing completion hook (covers success, cancellation, and drop).
- `Internals.Session.Configuration.maximumConcurrentConnections` threads the value from the public `Session` modifier down to `Internals.ClientManager._createNewClient`.
- `Internals.Client.execute(...)` is now `async` (it previously fired the request synchronously); the two call sites (`Internals.Session.execute` and the cache-control HEAD revalidation path) already ran in async context.

## Test plan
- [x] New test proving the limiter actually throttles concurrency (`InternalsClientConcurrencyLimitTests`), using a hanging TCP server to deterministically observe that only N requests start before the rest queue.
- [x] New wiring test confirming the `Session` modifier reaches `Internals.Session.Configuration` (`SessionTests.session_whenMaxConcurrentConnections_shouldBeValid`).
- [x] Full suite: `swift test` — 1105 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)