### PR TITLE
Return Self from Session.enableNetworkFramework(_:)

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Session/Session/Session.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Session/Session.swift
@@ -108,7 +108,7 @@ public struct Session: Property {
     /// - Parameter enabled: The flag to enable the Network framework
     /// - Returns: A modified property with Network framework enabled.
     ///
-    public func enableNetworkFramework(_ enabled: Bool = true) -> some Property {
+    public func enableNetworkFramework(_ enabled: Bool = true) -> Self {
         edit { $0.enableNetworkFramework = enabled }
     }
 


### PR DESCRIPTION
## Summary
- `Session.enableNetworkFramework(_:)` returned `some Property` instead of `Self`, unlike every other `Session` modifier. The opaque return type erased the concrete `Session` type, so it couldn't be chained with other `Session`-specific modifiers (e.g. `.enableNetworkFramework(true).maximumConnectionsPerHost(10)` didn't compile).
- Changes the return type to `Self`, matching the rest of the modifiers in `Session.swift`.

This is a **source-breaking change** for any call site that depended on the return type being the opaque `some Property` rather than the concrete `Session` type (e.g. explicit type annotations naming the opaque type).

## Test plan
- [x] `swift build` — clean.
- [x] `swift test --filter SessionTests` — passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)