### PR TITLE
Add RDLImage image loading for SwiftUI, UIKit, AppKit and watchOS

### DIFF
--- a/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Making your request secure/Secure-connection.md
+++ b/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Making your request secure/Secure-connection.md
@@ -76,7 +76,7 @@ PrivateKey(privateFile1)
 
 Using shared symmetric keys between the server and the client, PSK is a secure way to communicate with the server.
 
-The configuration is simple and only requires implementing the ``SSLPSKIdentityResolver``. When using it in the ``Property``, you should secure the instance of the implemented resolver using ``StoredObject`` to optimize the code.
+The configuration is simple and only requires implementing the `SSLPSKIdentityResolver` protocol. When using it in the ``Property``, you should secure the instance of the implemented resolver using ``StoredObject`` to optimize the code.
 
 ```swift 
 struct GithubAPI: Property {
@@ -123,7 +123,6 @@ This rule is necessary to avoid the instantiation of new clients provided by `As
 ### Working with PSK
 
 - ``RequestDL/PSKIdentity``
-- ``RequestDL/SSLPSKIdentityResolver``
 
 ### The TLS configuration
 
@@ -133,4 +132,3 @@ This rule is necessary to avoid the instantiation of new clients provided by `As
 - ``RequestDL/CertificateVerification``
 - ``RequestDL/SignatureAlgorithm``
 - ``RequestDL/RenegotiationSupport``
-- ``RequestDL/SSLKeyLogger``

--- a/Sources/RequestDL/Documentation.docc/Essentials/Executing the Request/Executing-the-request.md
+++ b/Sources/RequestDL/Documentation.docc/Essentials/Executing the Request/Executing-the-request.md
@@ -17,3 +17,7 @@ Discover the possibilities to execute your request and manipulate the received d
 ### Monitoring upload and download progress
 
 - <doc:Upload-and-download-progress>
+
+### Loading images
+
+- <doc:Loading-images>

--- a/Sources/RequestDL/Documentation.docc/Essentials/Executing the Request/For Everybody/Swift-concurrency.md
+++ b/Sources/RequestDL/Documentation.docc/Essentials/Executing the Request/For Everybody/Swift-concurrency.md
@@ -62,4 +62,3 @@ In addition, each received element is inserted into a queue that remains availab
 
 - ``RequestDL/AsyncResponse``
 - ``RequestDL/AsyncBytes``
-- ``RequestDL/AlreadyConsumedError``

--- a/Sources/RequestDL/Documentation.docc/Essentials/Executing the Request/Loading Images/Loading-images.md
+++ b/Sources/RequestDL/Documentation.docc/Essentials/Executing the Request/Loading Images/Loading-images.md
@@ -1,0 +1,116 @@
+# Loading images
+
+Load and display images directly from a URL or a request, using RequestDL's own pipeline and cache — for SwiftUI, UIKit, AppKit, and watchOS.
+
+## Overview
+
+Loading an image is just another way of consuming a request's result: fetch the bytes, decode them, and show whatever came back. RequestDL's image loading APIs are built as a thin layer on top of the same pieces used everywhere else in the package — ``RequestDL/DataTask``, ``RequestDL/DataCache``, ``RequestDL/Property/cachePolicy(_:)``, ``RequestDL/Property/cacheStrategy(_:)`` — so anything you already know about caching and configuring a request applies here too.
+
+Four entry points share one engine, ``RequestDL/RDLImageLoader``:
+
+- ``RequestDL/RDLImage``, a SwiftUI view that mirrors `AsyncImage`.
+- `UIImageView.rdl`, on iOS and tvOS.
+- `NSImageView.rdl`, on macOS.
+- `WKInterfaceImage.rdl`, on watchOS.
+
+> Important: Concurrent loads that share the same identifier are deduplicated by ``RequestDL/RDLImageLoader`` — only one request is in flight at a time per identifier, and every caller waiting on it gets the same result. This is separate from, and on top of, RequestDL's own response cache: the dedupe layer is what makes many views asking for the same image *at once* cheap, while the cache is what makes asking for it again *later* cheap.
+
+### RDLImage
+
+`RDLImage` mirrors `AsyncImage`'s API — the same URL-based initializers, `AsyncImagePhase`-like driven rendering, and content/placeholder convenience:
+
+```swift
+RDLImage(url: url) { image in
+    image.resizable()
+} placeholder: {
+    ProgressView()
+}
+
+RDLImage(url: url) { phase in
+    switch phase {
+    case .empty:
+        ProgressView()
+    case .success(let image):
+        image.resizable()
+    case .failure:
+        Image(systemName: "photo")
+    @unknown default:
+        EmptyView()
+    }
+}
+```
+
+Use the ``RequestDL/RDLImage/init(id:scale:transaction:loader:task:content:)`` initializer when the request needs more than a URL — custom headers, authentication, a specific ``RequestDL/Property/cachePolicy(_:)``, and so on — by building it the same way a ``RequestDL/DataTask`` is built:
+
+```swift
+RDLImage(
+    id: "avatar",
+    task: DataTask {
+        BaseURL("cdn.example.com")
+        Path("avatar.png")
+        CustomHeader(name: "Authorization", value: token)
+    }
+) { phase in
+    // ...
+}
+```
+
+Any ``RequestDL/RequestTask`` producing a ``RequestDL/TaskResult`` of `Data` works here, so a ``RequestDL/MockedTask`` also drops in directly — handy for SwiftUI previews and tests that shouldn't hit the network.
+
+> Important: `id` identifies the request for both restarting the load — when it changes, the current load is cancelled and a new one begins, the same way `AsyncImage` reacts to a new `url` — and deduplicating concurrent loads in ``RequestDL/RDLImageLoader``. It can't be derived automatically from an arbitrary ``RequestDL/RequestTask``, so you supply it explicitly, typically the URL or endpoint the request resolves to.
+
+### UIImageView, NSImageView, and WKInterfaceImage
+
+The same two entry points — a plain `URL` or an already-built ``RequestDL/RequestTask`` — are available on `UIImageView`, `NSImageView`, and `WKInterfaceImage`, through the `.rdl` namespace so they don't add members directly to those types:
+
+```swift
+imageView.rdl.setImage(with: url, placeholder: UIImage(named: "placeholder"))
+
+imageView.rdl.setImage(
+    id: "avatar",
+    task: DataTask {
+        BaseURL("cdn.example.com")
+        Path("avatar.png")
+        CustomHeader(name: "Authorization", value: token)
+    }
+) { result in
+    switch result {
+    case .success(let image):
+        // ...
+    case .failure(let error):
+        // ...
+    }
+}
+```
+
+Every `setImage` call cancels whatever load is already in flight on that image view first, which is what makes it safe to call from `tableView(_:cellForRowAt:)`, `collectionView(_:cellForItemAt:)`, or a `WKInterfaceTable` row controller — a cell recycled mid-load never has a stale image land on it after the fact. Call `.rdl.cancel()` directly (for instance, from `prepareForReuse()`) to stop a load without starting another.
+
+> Note: `WKInterfaceImage` doesn't expose a way to read the image back — `WKInterfaceObject` types are one-way proxies to a system-rendered element — so use the `completion` handler if you need to react to the result there.
+
+### RDLImageLoader
+
+``RequestDL/RDLImageLoader`` is the engine behind all four entry points above, and you can use it directly:
+
+```swift
+let image = try await RDLImageLoader.shared.load(url: url)
+```
+
+``RequestDL/RDLImageLoader/shared`` is what every entry point uses by default, so unrelated call sites requesting the same image still dedupe against each other. Create your own instance — every initializer above accepts a `loader:` parameter — when you want independent dedupe bookkeeping, for instance to isolate a screen's previews from the rest of the app.
+
+## Topics
+
+### The shared engine
+
+- ``RequestDL/RDLImageLoader``
+- ``RequestDL/PlatformImage``
+- ``RequestDL/RDLImageDecodingError``
+
+### SwiftUI
+
+- ``RequestDL/RDLImage``
+- ``RequestDL/RDLImagePhase``
+
+### UIKit, AppKit, and WatchKit
+
+- ``RequestDL/RDLCompatible``
+- ``RequestDL/RDLWrapper``

--- a/Sources/RequestDL/Documentation.docc/RequestDL.md
+++ b/Sources/RequestDL/Documentation.docc/RequestDL.md
@@ -77,6 +77,7 @@ try await DataTask {
 - [x] [Upload & Download progress](<doc:Upload-and-download-progress>);
 - [x] [Swift Concurrency](<doc:Swift-concurrency>);
 - [x] [Combine support](<doc:Exploring-combine>) (Apple platforms only);
+- [x] [Image loading for SwiftUI, UIKit, AppKit and watchOS](<doc:Loading-images>) (Apple platforms only);
 
 We are excited to expand this list with many other features. Start by making your contribution in [Discussions](https://github.com/orgs/request-dl/discussions) or by opening a PR (Pull Request).
 

--- a/Sources/RequestDL/Image/AppKit/NSImageView+RequestDL.swift
+++ b/Sources/RequestDL/Image/AppKit/NSImageView+RequestDL.swift
@@ -1,0 +1,138 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(AppKit)
+import AppKit
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.URL
+import struct Foundation.Data
+#endif
+
+/// Backs the in-flight load tracked on each `NSImageView`, via the standard Swift
+/// associated-object pattern: only this variable's stable address is ever used, its value is
+/// never read or written, so `nonisolated(unsafe)` is safe.
+private nonisolated(unsafe) var rdlLoadTaskKey: UInt8 = 0
+
+extension NSImageView: RDLCompatible {}
+
+extension RDLWrapper where Base: NSImageView {
+
+    /// The in-flight load started by `setImage`, if any.
+    ///
+    /// Reading and writing this is what makes reuse in `NSTableView`/`NSCollectionView` safe:
+    /// every `setImage` call cancels whatever load is already in flight on this image view
+    /// before starting its own, so a view that gets recycled mid-load never has a stale image
+    /// land on it afterwards.
+    private var loadTask: Task<Void, Never>? {
+        get { objc_getAssociatedObject(base, &rdlLoadTaskKey) as? Task<Void, Never> }
+        nonmutating set { objc_setAssociatedObject(base, &rdlLoadTaskKey, newValue, .OBJC_ASSOCIATION_RETAIN) }
+    }
+
+    ///
+    /// Cancels the in-flight load, if any, started by `setImage` on this image view.
+    ///
+    public func cancel() {
+        loadTask?.cancel()
+        loadTask = nil
+    }
+
+    ///
+    /// Loads the image at `url` and sets it on this image view once it arrives.
+    ///
+    /// Cancels any load already in flight on this image view before starting — safe to call from
+    /// a table/collection view's item provider even when views are reused faster than their
+    /// previous image finishes loading.
+    ///
+    /// - Parameters:
+    ///    - url: The URL of the image.
+    ///    - placeholder: The image to set immediately, shown until the load finishes.
+    ///    - loader: The ``RDLImageLoader`` performing the request. Defaults to ``RDLImageLoader/shared``.
+    ///    - completion: Called once the load finishes, on the main actor. Not called if the load
+    ///    is cancelled by a later `setImage`/`cancel()` call on this image view.
+    ///
+    public func setImage(
+        with url: URL,
+        placeholder: NSImage? = nil,
+        loader: RDLImageLoader = .shared,
+        completion: (@Sendable (Result<NSImage, Error>) -> Void)? = nil
+    ) {
+        cancel()
+
+        if let placeholder {
+            base.image = placeholder
+        }
+
+        run({ try await loader.load(url: url) }, completion: completion)
+    }
+
+    ///
+    /// Loads `task` and sets its image on this image view once it arrives.
+    ///
+    /// Use this when the request needs more than a URL — custom headers, authentication, a
+    /// specific ``Property/cachePolicy(_:)``, and so on — by building `task` the same way a
+    /// ``DataTask`` is built. Any ``RequestTask`` producing a ``TaskResult`` of `Data` works, so a
+    /// ``MockedTask`` also drops in directly.
+    ///
+    /// Cancels any load already in flight on this image view before starting — safe to call from
+    /// a table/collection view's item provider even when views are reused faster than their
+    /// previous image finishes loading.
+    ///
+    /// - Parameters:
+    ///    - id: A stable identifier for the request, used to deduplicate concurrent loads. It
+    ///    can't be derived automatically from an arbitrary ``RequestTask``, so callers supply it
+    ///    explicitly — typically the URL or endpoint the request resolves to.
+    ///    - task: The task that performs the request, e.g. a ``DataTask``.
+    ///    - placeholder: The image to set immediately, shown until the load finishes.
+    ///    - loader: The ``RDLImageLoader`` performing the request. Defaults to ``RDLImageLoader/shared``.
+    ///    - completion: Called once the load finishes, on the main actor. Not called if the load
+    ///    is cancelled by a later `setImage`/`cancel()` call on this image view.
+    ///
+    public func setImage<ImageTask: RequestTask<TaskResult<Data>>>(
+        id: String,
+        task: ImageTask,
+        placeholder: NSImage? = nil,
+        loader: RDLImageLoader = .shared,
+        completion: (@Sendable (Result<NSImage, Error>) -> Void)? = nil
+    ) {
+        cancel()
+
+        if let placeholder {
+            base.image = placeholder
+        }
+
+        run({ try await loader.load(id: id, task: task) }, completion: completion)
+    }
+
+    // MARK: - Private methods
+
+    private func run(
+        _ load: @escaping @Sendable () async throws -> NSImage,
+        completion: (@Sendable (Result<NSImage, Error>) -> Void)?
+    ) {
+        let imageView = base
+
+        loadTask = Task { @MainActor in
+            do {
+                let image = try await load()
+                try Task.checkCancellation()
+
+                imageView.image = image
+                completion?(.success(image))
+            } catch is CancellationError {
+                // A later `setImage`/`cancel()` call already replaced this load.
+            } catch {
+                guard !Task.isCancelled else {
+                    return
+                }
+
+                completion?(.failure(error))
+            }
+        }
+    }
+}
+
+#endif

--- a/Sources/RequestDL/Image/AppKit/NSImageView+RequestDL.swift
+++ b/Sources/RequestDL/Image/AppKit/NSImageView+RequestDL.swift
@@ -2,7 +2,11 @@
 // See LICENSE for this package's licensing information.
 //
 
-#if canImport(AppKit)
+// `canImport(AppKit)` is true under Mac Catalyst too, but `NSImageView` itself is marked
+// unavailable there — Catalyst apps use `UIImageView` (see UIImageView+RequestDL.swift), which
+// `canImport(UIKit)` picks up on its own. Excluded explicitly so this file doesn't fail to
+// compile for that target.
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 
 #if canImport(FoundationEssentials)
@@ -19,6 +23,10 @@ private nonisolated(unsafe) var rdlLoadTaskKey: UInt8 = 0
 
 extension NSImageView: RDLCompatible {}
 
+/// `@MainActor`-isolated because `NSImageView.image` is: setting it synchronously from
+/// `setImage` (the `placeholder` assignment, ahead of the actual load) needs the compiler to
+/// know it's already on the main actor, not just that it happens to run there in practice.
+@MainActor
 extension RDLWrapper where Base: NSImageView {
 
     /// The in-flight load started by `setImage`, if any.

--- a/Sources/RequestDL/Image/Core/PlatformImage.swift
+++ b/Sources/RequestDL/Image/Core/PlatformImage.swift
@@ -1,0 +1,38 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(UIKit)
+import UIKit
+
+/// The platform-native image type used by RequestDL's image loading APIs.
+///
+/// Resolves to `UIImage` on iOS, tvOS and watchOS, and to `NSImage` on macOS.
+public typealias PlatformImage = UIImage
+#elseif canImport(AppKit)
+import AppKit
+
+/// The platform-native image type used by RequestDL's image loading APIs.
+///
+/// Resolves to `UIImage` on iOS, tvOS and watchOS, and to `NSImage` on macOS.
+public typealias PlatformImage = NSImage
+#endif
+
+#if canImport(UIKit) || canImport(AppKit)
+
+/// A `Sendable` box around ``PlatformImage``.
+///
+/// `UIImage`/`NSImage` are reference types that predate Swift concurrency and are not marked
+/// `Sendable`, even though handing a fully-initialized instance across an isolation boundary is
+/// safe in practice: nothing here mutates it after decoding. The box exists only to satisfy the
+/// compiler at that single crossing point.
+struct SendableImage: @unchecked Sendable {
+
+    let image: PlatformImage
+
+    init(_ image: PlatformImage) {
+        self.image = image
+    }
+}
+
+#endif

--- a/Sources/RequestDL/Image/Core/RDLImageDecodingError.swift
+++ b/Sources/RequestDL/Image/Core/RDLImageDecodingError.swift
@@ -1,0 +1,14 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(UIKit) || canImport(AppKit)
+
+/// An error thrown when a response's data could not be decoded into a ``PlatformImage``.
+public struct RDLImageDecodingError: TaskError {
+
+    /// Creates the error.
+    public init() {}
+}
+
+#endif

--- a/Sources/RequestDL/Image/Core/RDLImageLoader.swift
+++ b/Sources/RequestDL/Image/Core/RDLImageLoader.swift
@@ -1,0 +1,118 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(UIKit) || canImport(AppKit)
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.URL
+import struct Foundation.Data
+#endif
+
+/// Loads and decodes images through RequestDL's request pipeline, reusing its cache
+/// (``DataCache``, ``Property/cachePolicy(_:)``, ``Property/cacheStrategy(_:)``) and adding a
+/// dedupe layer of its own.
+///
+/// Concurrent calls for the same `id` share a single in-flight download: the first call starts
+/// it, and every other call that arrives before it finishes awaits the same result instead of
+/// starting a second request. This is separate from — and on top of — RequestDL's own response
+/// cache, which is what makes a *later*, non-concurrent request for the same image cheap.
+public actor RDLImageLoader {
+
+    /// The shared loader instance, used by RequestDL's SwiftUI, UIKit, AppKit and WatchKit
+    /// integrations by default.
+    public static let shared = RDLImageLoader()
+
+    // MARK: - Private properties
+
+    /// In-flight downloads, keyed by the caller-supplied `id`.
+    ///
+    /// Cleared as soon as the task finishes (success or failure): this tracks concurrency, not
+    /// results. A request that lands after this is cleared starts fresh rather than reusing a
+    /// stale entry — RequestDL's own cache is what makes that repeat request cheap.
+    private var tasks: [String: Task<SendableImage, Error>] = [:]
+
+    // MARK: - Inits
+
+    /// Creates a new, independent loader with its own dedupe bookkeeping.
+    ///
+    /// Most callers should use ``shared`` instead, so unrelated call sites requesting the same
+    /// image still dedupe against each other.
+    public init() {}
+
+    // MARK: - Public methods
+
+    ///
+    /// Loads and decodes the image described by `task`.
+    ///
+    /// - Parameters:
+    ///    - id: A stable identifier for the request, used to deduplicate concurrent loads that
+    ///    describe the same image. Callers using ``load(url:)`` get this for free from the URL;
+    ///    callers building their own ``RequestTask`` choose it themselves.
+    ///    - task: The task that performs the request, e.g. a ``DataTask``.
+    /// - Returns: The decoded image.
+    /// - Throws: An error if the request fails or the response could not be decoded.
+    ///
+    public func load<Content: RequestTask<TaskResult<Data>>>(
+        id: String,
+        task: Content
+    ) async throws -> PlatformImage {
+        if let existing = tasks[id] {
+            return try await existing.value.image
+        }
+
+        let newTask = Task<SendableImage, Error> {
+            let result = try await task.result()
+
+            guard let image = PlatformImage(data: result.payload) else {
+                throw RDLImageDecodingError()
+            }
+
+            return SendableImage(image)
+        }
+
+        tasks[id] = newTask
+        defer { tasks[id] = nil }
+
+        return try await newTask.value.image
+    }
+
+    ///
+    /// Loads and decodes the image at `url`, deduplicating against any other concurrent load of
+    /// the same URL.
+    ///
+    /// - Parameter url: The URL of the image.
+    /// - Returns: The decoded image.
+    /// - Throws: An error if the request fails or the response could not be decoded.
+    ///
+    public func load(url: URL) async throws -> PlatformImage {
+        try await load(
+            id: url.absoluteString,
+            task: DataTask { URLImageProperty(url: url) }
+        )
+    }
+
+    ///
+    /// Loads and decodes the image described by `content`, in the same manner as ``DataTask``.
+    ///
+    /// Use this when the request needs more than a URL — custom headers, authentication, a
+    /// specific ``Property/cachePolicy(_:)``, and so on.
+    ///
+    /// - Parameters:
+    ///    - id: A stable identifier for the request, used to deduplicate concurrent loads that
+    ///    describe the same image.
+    ///    - content: The content describing the request.
+    /// - Returns: The decoded image.
+    /// - Throws: An error if the request fails or the response could not be decoded.
+    ///
+    public func load<Content: Property>(
+        id: String,
+        @PropertyBuilder content: () -> Content
+    ) async throws -> PlatformImage {
+        try await load(id: id, task: DataTask(content: content))
+    }
+}
+
+#endif

--- a/Sources/RequestDL/Image/Core/RDLWrapper.swift
+++ b/Sources/RequestDL/Image/Core/RDLWrapper.swift
@@ -1,0 +1,33 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(UIKit) || canImport(AppKit)
+
+/// A namespace that exposes RequestDL's image loading APIs without adding members directly to
+/// the wrapped type, e.g. `imageView.rdl.setImage(with: url)`.
+public struct RDLWrapper<Base: AnyObject> {
+
+    /// The wrapped instance.
+    public let base: Base
+
+    init(_ base: Base) {
+        self.base = base
+    }
+}
+
+/// A type that exposes RequestDL's image loading APIs through its `rdl` property.
+///
+/// Conform `UIImageView`, `NSImageView` and `WKInterfaceImage` to this protocol to make
+/// `someView.rdl.setImage(...)` available on them.
+public protocol RDLCompatible: AnyObject {}
+
+extension RDLCompatible {
+
+    /// A namespace for RequestDL's image loading APIs, e.g. `imageView.rdl.setImage(with: url)`.
+    public var rdl: RDLWrapper<Self> {
+        RDLWrapper(self)
+    }
+}
+
+#endif

--- a/Sources/RequestDL/Image/Core/URLImageProperty.swift
+++ b/Sources/RequestDL/Image/Core/URLImageProperty.swift
@@ -1,0 +1,84 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(UIKit) || canImport(AppKit)
+import Foundation
+
+/// Translates a plain `URL` into the `BaseURL`/`Path`/query building blocks RequestDL already
+/// uses to describe a request, so ``RDLImageLoader`` can accept a `URL` without a separate
+/// request pipeline.
+struct URLImageProperty: Property {
+
+    let url: URL
+
+    var body: some Property {
+        BaseURL(URLScheme(url.scheme ?? "https"), host: hostWithPort)
+
+        if !url.path.isEmpty {
+            Path(url.path)
+        }
+
+        QueryItemsProperty(items: percentEncodedQueryItems)
+    }
+
+    private var hostWithPort: String {
+        guard let host = url.host else {
+            return ""
+        }
+
+        guard let port = url.port else {
+            return host
+        }
+
+        return "\(host):\(port)"
+    }
+
+    /// - Important: Read as `percentEncodedQueryItems`, not `queryItems`. Everything RequestDL
+    /// stores in ``RequestConfiguration/queries`` is expected to already be percent encoded
+    /// (see its doc comment) — encoding it a second time here would turn every `%20` the URL
+    /// already carries into `%2520`.
+    private var percentEncodedQueryItems: [URLQueryItem] {
+        URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .percentEncodedQueryItems ?? []
+    }
+}
+
+/// Appends a fixed list of already-resolved query items.
+///
+/// A plain `Property` leaf rather than a loop of ``Query`` inside a `@PropertyBuilder` block,
+/// because `PropertyBuilder` has no `buildArray`: it cannot compose a variable-length list of
+/// properties from a `for` loop. Writing directly to `RequestConfiguration.queries` — exactly
+/// what `Query`'s own node does — sidesteps that limitation for a list whose length isn't known
+/// until the `URL` is inspected at runtime.
+private struct QueryItemsProperty: Property {
+
+    private struct Node: PropertyNode {
+
+        let items: [URLQueryItem]
+
+        func make(_ make: inout Make) async throws {
+            for item in items {
+                make.requestConfiguration.queries.append(
+                    QueryItem(name: item.name, value: item.value ?? "")
+                )
+            }
+        }
+    }
+
+    var body: Never {
+        bodyException()
+    }
+
+    let items: [URLQueryItem]
+
+    static func _makeProperty(
+        property: _GraphValue<QueryItemsProperty>,
+        inputs: _PropertyInputs
+    ) async throws -> _PropertyOutputs {
+        property.assertPathway()
+        return .leaf(Node(items: property.items))
+    }
+}
+
+#endif

--- a/Sources/RequestDL/Image/SwiftUI/Image+PlatformImage.swift
+++ b/Sources/RequestDL/Image/SwiftUI/Image+PlatformImage.swift
@@ -1,0 +1,50 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(SwiftUI) && canImport(UIKit)
+import SwiftUI
+import UIKit
+
+extension Image {
+
+    /// Wraps a decoded ``PlatformImage``, reinterpreting it at `scale` when it differs from the
+    /// image's own.
+    ///
+    /// Rewrapping the existing `CGImage` at a new scale is cheap — no re-decoding of the
+    /// original data — which is what makes it worth doing here instead of threading `scale`
+    /// through ``RDLImageLoader`` decoding: the loader dedupes concurrent loads of the same `id`
+    /// into a single decoded image shared by every caller, and callers are free to ask for
+    /// different scales.
+    init(platformImage: PlatformImage, scale: CGFloat) {
+        guard scale != platformImage.scale, let cgImage = platformImage.cgImage else {
+            self.init(uiImage: platformImage)
+            return
+        }
+
+        self.init(
+            uiImage: UIImage(
+                cgImage: cgImage,
+                scale: scale,
+                orientation: platformImage.imageOrientation
+            )
+        )
+    }
+}
+
+#elseif canImport(SwiftUI) && canImport(AppKit)
+import AppKit
+import SwiftUI
+
+extension Image {
+
+    /// Wraps a decoded ``PlatformImage``.
+    ///
+    /// - Note: `scale` has no effect on macOS: `NSImage` doesn't model resolution the way
+    /// `UIImage` does, so there's nothing to reinterpret it against.
+    init(platformImage: PlatformImage, scale: CGFloat) {
+        self.init(nsImage: platformImage)
+    }
+}
+
+#endif

--- a/Sources/RequestDL/Image/SwiftUI/RDLImage.swift
+++ b/Sources/RequestDL/Image/SwiftUI/RDLImage.swift
@@ -1,0 +1,217 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(SwiftUI) && (canImport(UIKit) || canImport(AppKit))
+import SwiftUI
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.URL
+import struct Foundation.Data
+#endif
+
+/// A view that asynchronously loads and displays an image, using RequestDL's request pipeline
+/// and cache.
+///
+/// `RDLImage` mirrors `AsyncImage`, with the same phase-driven and content/placeholder-driven
+/// initializers built on a `URL`:
+///
+/// ```swift
+/// RDLImage(url: url) { image in
+///     image.resizable()
+/// } placeholder: {
+///     ProgressView()
+/// }
+///
+/// RDLImage(url: url) { phase in
+///     switch phase {
+///     case .empty:
+///         ProgressView()
+///     case .success(let image):
+///         image.resizable()
+///     case .failure:
+///         Image(systemName: "photo")
+///     }
+/// }
+/// ```
+///
+/// Use the ``init(id:scale:transaction:loader:task:content:)`` initializer when the request needs
+/// more than a URL — custom headers, authentication, a specific ``Property/cachePolicy(_:)``, and
+/// so on — by building it the same way a ``DataTask`` is built:
+///
+/// ```swift
+/// RDLImage(
+///     id: "avatar",
+///     task: DataTask {
+///         BaseURL("cdn.example.com")
+///         Path("avatar.png")
+///         CustomHeader(name: "Authorization", value: token)
+///     }
+/// ) { phase in
+///     ...
+/// }
+/// ```
+///
+/// Any ``RequestTask`` producing a ``TaskResult`` of `Data` works, so a ``MockedTask`` also drops
+/// in directly — handy for previews and tests that shouldn't hit the network.
+///
+/// - Important: `id` identifies the request for both restarting the load (when it changes, the
+/// current load is cancelled and a new one begins, same as `AsyncImage` reacting to a new `url`)
+/// and deduplicating concurrent loads in ``RDLImageLoader``. It can't be derived automatically
+/// from an arbitrary ``RequestTask``, so callers supply it explicitly — typically the URL or
+/// endpoint the request resolves to.
+public struct RDLImage<Content: View>: View {
+
+    // MARK: - Private properties
+
+    @State private var phase: RDLImagePhase = .empty
+
+    private let id: String?
+    private let scale: CGFloat
+    private let transaction: Transaction
+    private let load: (@Sendable () async throws -> PlatformImage)?
+    private let content: (RDLImagePhase) -> Content
+
+    // MARK: - Public properties
+
+    public var body: some View {
+        content(phase)
+            .task(id: id) {
+                await runLoad()
+            }
+    }
+
+    // MARK: - Inits
+
+    ///
+    /// Creates an image that loads `url` and renders through `content`, driven by the current
+    /// ``RDLImagePhase``.
+    ///
+    /// - Parameters:
+    ///    - url: The URL of the image to load. Passing `nil` keeps the view in the ``RDLImagePhase/empty``
+    ///    phase without starting a request.
+    ///    - scale: The scale to interpret the loaded image at. Only meaningful on platforms
+    ///    backed by `UIImage`; ignored on macOS.
+    ///    - transaction: The transaction used when the phase changes.
+    ///    - loader: The ``RDLImageLoader`` performing the request. Defaults to ``RDLImageLoader/shared``.
+    ///    - content: A closure producing the view to render for the current phase.
+    ///
+    public init(
+        url: URL?,
+        scale: CGFloat = 1,
+        transaction: Transaction = Transaction(),
+        loader: RDLImageLoader = .shared,
+        @ViewBuilder content: @escaping (RDLImagePhase) -> Content
+    ) {
+        self.id = url?.absoluteString
+        self.scale = scale
+        self.transaction = transaction
+        self.content = content
+
+        if let url {
+            self.load = { try await loader.load(url: url) }
+        } else {
+            self.load = nil
+        }
+    }
+
+    ///
+    /// Creates an image that loads `task` and renders through `content`, driven by the current
+    /// ``RDLImagePhase``.
+    ///
+    /// - Parameters:
+    ///    - id: A stable identifier for the request. See the type-level discussion above.
+    ///    - scale: The scale to interpret the loaded image at. Only meaningful on platforms
+    ///    backed by `UIImage`; ignored on macOS.
+    ///    - transaction: The transaction used when the phase changes.
+    ///    - loader: The ``RDLImageLoader`` performing the request. Defaults to ``RDLImageLoader/shared``.
+    ///    - task: The task that performs the request, e.g. a ``DataTask``.
+    ///    - content: A closure producing the view to render for the current phase.
+    ///
+    public init<ImageTask: RequestTask<TaskResult<Data>>>(
+        id: String,
+        scale: CGFloat = 1,
+        transaction: Transaction = Transaction(),
+        loader: RDLImageLoader = .shared,
+        task: ImageTask,
+        @ViewBuilder content: @escaping (RDLImagePhase) -> Content
+    ) {
+        self.id = id
+        self.scale = scale
+        self.transaction = transaction
+        self.content = content
+        self.load = { try await loader.load(id: id, task: task) }
+    }
+
+    // MARK: - Private methods
+
+    private func runLoad() async {
+        guard let load else {
+            phase = .empty
+            return
+        }
+
+        withTransaction(transaction) {
+            phase = .empty
+        }
+
+        do {
+            let image = try await load()
+            try Task.checkCancellation()
+
+            withTransaction(transaction) {
+                phase = .success(Image(platformImage: image, scale: scale))
+            }
+        } catch is CancellationError {
+            // The view's identity changed, or it disappeared, before the load finished. Leaving
+            // `phase` untouched matches SwiftUI's own `.task(id:)` semantics: a cancelled task
+            // shouldn't commit a result.
+        } catch {
+            guard !Task.isCancelled else {
+                return
+            }
+
+            withTransaction(transaction) {
+                phase = .failure(error)
+            }
+        }
+    }
+}
+
+// MARK: - Content/placeholder convenience inits
+
+extension RDLImage {
+
+    ///
+    /// Creates an image that loads `url`, rendering `content` on success and `placeholder`
+    /// otherwise.
+    ///
+    /// - Parameters:
+    ///    - url: The URL of the image to load. Passing `nil` keeps `placeholder` on screen
+    ///    without starting a request.
+    ///    - scale: The scale to interpret the loaded image at. Only meaningful on platforms
+    ///    backed by `UIImage`; ignored on macOS.
+    ///    - loader: The ``RDLImageLoader`` performing the request. Defaults to ``RDLImageLoader/shared``.
+    ///    - content: A closure producing the view to render once the image has loaded.
+    ///    - placeholder: A closure producing the view to render while loading or on failure.
+    ///
+    public init<I: View, P: View>(
+        url: URL?,
+        scale: CGFloat = 1,
+        loader: RDLImageLoader = .shared,
+        @ViewBuilder content: @escaping (Image) -> I,
+        @ViewBuilder placeholder: @escaping () -> P
+    ) where Content == _ConditionalContent<I, P> {
+        self.init(url: url, scale: scale, loader: loader) { phase in
+            if let image = phase.image {
+                content(image)
+            } else {
+                placeholder()
+            }
+        }
+    }
+}
+
+#endif

--- a/Sources/RequestDL/Image/SwiftUI/RDLImagePhase.swift
+++ b/Sources/RequestDL/Image/SwiftUI/RDLImagePhase.swift
@@ -1,0 +1,40 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(SwiftUI) && (canImport(UIKit) || canImport(AppKit))
+import SwiftUI
+
+/// The current phase of an ``RDLImage``'s asynchronous load.
+public enum RDLImagePhase {
+
+    /// No image has loaded yet, either because the load hasn't started, is still in flight, or
+    /// there is no request to run.
+    case empty
+
+    /// An image finished loading successfully.
+    case success(Image)
+
+    /// The load finished with an error.
+    case failure(Error)
+
+    /// The loaded image, if the phase is ``success(_:)``.
+    public var image: Image? {
+        guard case .success(let image) = self else {
+            return nil
+        }
+
+        return image
+    }
+
+    /// The error that ended the load, if the phase is ``failure(_:)``.
+    public var error: Error? {
+        guard case .failure(let error) = self else {
+            return nil
+        }
+
+        return error
+    }
+}
+
+#endif

--- a/Sources/RequestDL/Image/UIKit/UIImageView+RequestDL.swift
+++ b/Sources/RequestDL/Image/UIKit/UIImageView+RequestDL.swift
@@ -1,0 +1,138 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(UIKit) && !os(watchOS)
+import UIKit
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.URL
+import struct Foundation.Data
+#endif
+
+/// Backs the in-flight load tracked on each `UIImageView`, via the standard Swift
+/// associated-object pattern: only this variable's stable address is ever used, its value is
+/// never read or written, so `nonisolated(unsafe)` is safe.
+private nonisolated(unsafe) var rdlLoadTaskKey: UInt8 = 0
+
+extension UIImageView: RDLCompatible {}
+
+extension RDLWrapper where Base: UIImageView {
+
+    /// The in-flight load started by `setImage`, if any.
+    ///
+    /// Reading and writing this is what makes reuse in `UITableView`/`UICollectionView` safe:
+    /// every `setImage` call cancels whatever load is already in flight on this image view
+    /// before starting its own, so a cell that gets recycled mid-load never has a stale image
+    /// land on it afterwards.
+    private var loadTask: Task<Void, Never>? {
+        get { objc_getAssociatedObject(base, &rdlLoadTaskKey) as? Task<Void, Never> }
+        nonmutating set { objc_setAssociatedObject(base, &rdlLoadTaskKey, newValue, .OBJC_ASSOCIATION_RETAIN) }
+    }
+
+    ///
+    /// Cancels the in-flight load, if any, started by `setImage` on this image view.
+    ///
+    public func cancel() {
+        loadTask?.cancel()
+        loadTask = nil
+    }
+
+    ///
+    /// Loads the image at `url` and sets it on this image view once it arrives.
+    ///
+    /// Cancels any load already in flight on this image view before starting — safe to call
+    /// from `tableView(_:cellForRowAt:)`/`collectionView(_:cellForItemAt:)` even when cells are
+    /// reused faster than their previous image finishes loading.
+    ///
+    /// - Parameters:
+    ///    - url: The URL of the image.
+    ///    - placeholder: The image to set immediately, shown until the load finishes.
+    ///    - loader: The ``RDLImageLoader`` performing the request. Defaults to ``RDLImageLoader/shared``.
+    ///    - completion: Called once the load finishes, on the main actor. Not called if the load
+    ///    is cancelled by a later `setImage`/`cancel()` call on this image view.
+    ///
+    public func setImage(
+        with url: URL,
+        placeholder: UIImage? = nil,
+        loader: RDLImageLoader = .shared,
+        completion: (@Sendable (Result<UIImage, Error>) -> Void)? = nil
+    ) {
+        cancel()
+
+        if let placeholder {
+            base.image = placeholder
+        }
+
+        run({ try await loader.load(url: url) }, completion: completion)
+    }
+
+    ///
+    /// Loads `task` and sets its image on this image view once it arrives.
+    ///
+    /// Use this when the request needs more than a URL — custom headers, authentication, a
+    /// specific ``Property/cachePolicy(_:)``, and so on — by building `task` the same way a
+    /// ``DataTask`` is built. Any ``RequestTask`` producing a ``TaskResult`` of `Data` works, so a
+    /// ``MockedTask`` also drops in directly.
+    ///
+    /// Cancels any load already in flight on this image view before starting — safe to call
+    /// from `tableView(_:cellForRowAt:)`/`collectionView(_:cellForItemAt:)` even when cells are
+    /// reused faster than their previous image finishes loading.
+    ///
+    /// - Parameters:
+    ///    - id: A stable identifier for the request, used to deduplicate concurrent loads. It
+    ///    can't be derived automatically from an arbitrary ``RequestTask``, so callers supply it
+    ///    explicitly — typically the URL or endpoint the request resolves to.
+    ///    - task: The task that performs the request, e.g. a ``DataTask``.
+    ///    - placeholder: The image to set immediately, shown until the load finishes.
+    ///    - loader: The ``RDLImageLoader`` performing the request. Defaults to ``RDLImageLoader/shared``.
+    ///    - completion: Called once the load finishes, on the main actor. Not called if the load
+    ///    is cancelled by a later `setImage`/`cancel()` call on this image view.
+    ///
+    public func setImage<ImageTask: RequestTask<TaskResult<Data>>>(
+        id: String,
+        task: ImageTask,
+        placeholder: UIImage? = nil,
+        loader: RDLImageLoader = .shared,
+        completion: (@Sendable (Result<UIImage, Error>) -> Void)? = nil
+    ) {
+        cancel()
+
+        if let placeholder {
+            base.image = placeholder
+        }
+
+        run({ try await loader.load(id: id, task: task) }, completion: completion)
+    }
+
+    // MARK: - Private methods
+
+    private func run(
+        _ load: @escaping @Sendable () async throws -> UIImage,
+        completion: (@Sendable (Result<UIImage, Error>) -> Void)?
+    ) {
+        let imageView = base
+
+        loadTask = Task { @MainActor in
+            do {
+                let image = try await load()
+                try Task.checkCancellation()
+
+                imageView.image = image
+                completion?(.success(image))
+            } catch is CancellationError {
+                // A later `setImage`/`cancel()` call already replaced this load.
+            } catch {
+                guard !Task.isCancelled else {
+                    return
+                }
+
+                completion?(.failure(error))
+            }
+        }
+    }
+}
+
+#endif

--- a/Sources/RequestDL/Image/UIKit/UIImageView+RequestDL.swift
+++ b/Sources/RequestDL/Image/UIKit/UIImageView+RequestDL.swift
@@ -19,6 +19,10 @@ private nonisolated(unsafe) var rdlLoadTaskKey: UInt8 = 0
 
 extension UIImageView: RDLCompatible {}
 
+/// `@MainActor`-isolated because `UIImageView.image` is: setting it synchronously from
+/// `setImage` (the `placeholder` assignment, ahead of the actual load) needs the compiler to
+/// know it's already on the main actor, not just that it happens to run there in practice.
+@MainActor
 extension RDLWrapper where Base: UIImageView {
 
     /// The in-flight load started by `setImage`, if any.

--- a/Sources/RequestDL/Image/WatchKit/WKInterfaceImage+RequestDL.swift
+++ b/Sources/RequestDL/Image/WatchKit/WKInterfaceImage+RequestDL.swift
@@ -1,0 +1,143 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(WatchKit)
+import WatchKit
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.URL
+import struct Foundation.Data
+#endif
+
+/// Backs the in-flight load tracked on each `WKInterfaceImage`, via the standard Swift
+/// associated-object pattern: only this variable's stable address is ever used, its value is
+/// never read or written, so `nonisolated(unsafe)` is safe.
+private nonisolated(unsafe) var rdlLoadTaskKey: UInt8 = 0
+
+extension WKInterfaceImage: RDLCompatible {}
+
+/// `@MainActor`-isolated because, unlike `UIImageView`/`NSImageView`, `WKInterfaceImage` itself
+/// isn't annotated `@MainActor` in the WatchKit overlay — capturing `base` into the `Task` below
+/// would otherwise be flagged as sending a non-`Sendable`, non-isolated value across isolation
+/// domains. Matches how `WKInterfaceObject` is meant to be driven anyway: from the main thread.
+@MainActor
+extension RDLWrapper where Base: WKInterfaceImage {
+
+    /// The in-flight load started by `setImage`, if any.
+    ///
+    /// Reading and writing this is what makes reuse of rows in a `WKInterfaceTable` safe: every
+    /// `setImage` call cancels whatever load is already in flight on this interface image before
+    /// starting its own, so a row that gets recycled mid-load never has a stale image land on it
+    /// afterwards.
+    private var loadTask: Task<Void, Never>? {
+        get { objc_getAssociatedObject(base, &rdlLoadTaskKey) as? Task<Void, Never> }
+        nonmutating set { objc_setAssociatedObject(base, &rdlLoadTaskKey, newValue, .OBJC_ASSOCIATION_RETAIN) }
+    }
+
+    ///
+    /// Cancels the in-flight load, if any, started by `setImage` on this interface image.
+    ///
+    public func cancel() {
+        loadTask?.cancel()
+        loadTask = nil
+    }
+
+    ///
+    /// Loads the image at `url` and sets it on this interface image once it arrives.
+    ///
+    /// Cancels any load already in flight on this interface image before starting — safe to call
+    /// from a `WKInterfaceTable` row controller even when rows are reused faster than their
+    /// previous image finishes loading.
+    ///
+    /// - Parameters:
+    ///    - url: The URL of the image.
+    ///    - placeholder: The image to set immediately, shown until the load finishes.
+    ///    - loader: The ``RDLImageLoader`` performing the request. Defaults to ``RDLImageLoader/shared``.
+    ///    - completion: Called once the load finishes, on the main actor. Not called if the load
+    ///    is cancelled by a later `setImage`/`cancel()` call on this interface image.
+    ///
+    public func setImage(
+        with url: URL,
+        placeholder: UIImage? = nil,
+        loader: RDLImageLoader = .shared,
+        completion: (@Sendable (Result<UIImage, Error>) -> Void)? = nil
+    ) {
+        cancel()
+
+        if let placeholder {
+            base.setImage(placeholder)
+        }
+
+        run({ try await loader.load(url: url) }, completion: completion)
+    }
+
+    ///
+    /// Loads `task` and sets its image on this interface image once it arrives.
+    ///
+    /// Use this when the request needs more than a URL — custom headers, authentication, a
+    /// specific ``Property/cachePolicy(_:)``, and so on — by building `task` the same way a
+    /// ``DataTask`` is built. Any ``RequestTask`` producing a ``TaskResult`` of `Data` works, so a
+    /// ``MockedTask`` also drops in directly.
+    ///
+    /// Cancels any load already in flight on this interface image before starting — safe to call
+    /// from a `WKInterfaceTable` row controller even when rows are reused faster than their
+    /// previous image finishes loading.
+    ///
+    /// - Parameters:
+    ///    - id: A stable identifier for the request, used to deduplicate concurrent loads. It
+    ///    can't be derived automatically from an arbitrary ``RequestTask``, so callers supply it
+    ///    explicitly — typically the URL or endpoint the request resolves to.
+    ///    - task: The task that performs the request, e.g. a ``DataTask``.
+    ///    - placeholder: The image to set immediately, shown until the load finishes.
+    ///    - loader: The ``RDLImageLoader`` performing the request. Defaults to ``RDLImageLoader/shared``.
+    ///    - completion: Called once the load finishes, on the main actor. Not called if the load
+    ///    is cancelled by a later `setImage`/`cancel()` call on this interface image.
+    ///
+    public func setImage<ImageTask: RequestTask<TaskResult<Data>>>(
+        id: String,
+        task: ImageTask,
+        placeholder: UIImage? = nil,
+        loader: RDLImageLoader = .shared,
+        completion: (@Sendable (Result<UIImage, Error>) -> Void)? = nil
+    ) {
+        cancel()
+
+        if let placeholder {
+            base.setImage(placeholder)
+        }
+
+        run({ try await loader.load(id: id, task: task) }, completion: completion)
+    }
+
+    // MARK: - Private methods
+
+    private func run(
+        _ load: @escaping @Sendable () async throws -> UIImage,
+        completion: (@Sendable (Result<UIImage, Error>) -> Void)?
+    ) {
+        let interfaceImage = base
+
+        loadTask = Task { @MainActor in
+            do {
+                let image = try await load()
+                try Task.checkCancellation()
+
+                interfaceImage.setImage(image)
+                completion?(.success(image))
+            } catch is CancellationError {
+                // A later `setImage`/`cancel()` call already replaced this load.
+            } catch {
+                guard !Task.isCancelled else {
+                    return
+                }
+
+                completion?(.failure(error))
+            }
+        }
+    }
+}
+
+#endif

--- a/Tests/RequestDLTests/Image/AppKit/NSImageViewRequestDLTests.swift
+++ b/Tests/RequestDLTests/Image/AppKit/NSImageViewRequestDLTests.swift
@@ -8,7 +8,7 @@ import Testing
 
 @testable import RequestDL
 
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 
 @MainActor

--- a/Tests/RequestDLTests/Image/AppKit/NSImageViewRequestDLTests.swift
+++ b/Tests/RequestDLTests/Image/AppKit/NSImageViewRequestDLTests.swift
@@ -1,0 +1,149 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Foundation
+import SwiftAsyncStream
+import Testing
+
+@testable import RequestDL
+
+#if canImport(AppKit)
+import AppKit
+
+@MainActor
+struct NSImageViewRequestDLTests {
+
+    @Test
+    func setImageAppliesTheLoadedImage() async throws {
+        // Given
+        let imageView = NSImageView()
+        let signal = AsyncSignal()
+
+        // When
+        imageView.rdl.setImage(id: "one", task: StubImageTask { .init(head: .stub, payload: .onePixelPNG) }) { _ in
+            signal.signal()
+        }
+        try await signal.wait()
+
+        // Then
+        #expect(imageView.image != nil)
+    }
+
+    @Test
+    func placeholderIsAppliedImmediately() {
+        // Given
+        let imageView = NSImageView()
+        let placeholder = NSImage()
+
+        // When
+        imageView.rdl.setImage(
+            id: "slow",
+            task: StubImageTask {
+                try await Task.sleep(nanoseconds: 200_000_000)
+                return .init(head: .stub, payload: .onePixelPNG)
+            },
+            placeholder: placeholder
+        )
+
+        // Then
+        #expect(imageView.image === placeholder)
+        imageView.rdl.cancel()
+    }
+
+    @Test
+    func reusingTheImageViewCancelsThePreviousLoad() async throws {
+        // Given
+        let imageView = NSImageView()
+        let firstCompleted = Flag()
+        let secondSignal = AsyncSignal()
+
+        // When
+        imageView.rdl.setImage(
+            id: "first",
+            task: StubImageTask {
+                try await Task.sleep(nanoseconds: 300_000_000)
+                return .init(head: .stub, payload: .onePixelPNG)
+            }
+        ) { _ in
+            Task { await firstCompleted.set() }
+        }
+
+        imageView.rdl.setImage(id: "second", task: StubImageTask { .init(head: .stub, payload: .onePixelPNG) }) { _ in
+            secondSignal.signal()
+        }
+
+        try await secondSignal.wait()
+
+        // Give the first task's sleep enough time to also finish, to prove its completion never
+        // fires once superseded.
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        // Then
+        #expect(await !firstCompleted.value)
+        #expect(imageView.image != nil)
+    }
+
+    @Test
+    func cancelStopsThePendingLoad() async throws {
+        // Given
+        let imageView = NSImageView()
+        let completed = Flag()
+
+        // When
+        imageView.rdl.setImage(
+            id: "cancel-me",
+            task: StubImageTask {
+                try await Task.sleep(nanoseconds: 200_000_000)
+                return .init(head: .stub, payload: .onePixelPNG)
+            }
+        ) { _ in
+            Task { await completed.set() }
+        }
+        imageView.rdl.cancel()
+
+        try await Task.sleep(nanoseconds: 400_000_000)
+
+        // Then
+        #expect(await !completed.value)
+    }
+}
+
+// MARK: - Test helpers
+
+private struct StubImageTask: RequestTask {
+
+    let onResult: @Sendable () async throws -> TaskResult<Data>
+
+    func result() async throws -> TaskResult<Data> {
+        try await onResult()
+    }
+}
+
+private actor Flag {
+
+    private(set) var value = false
+
+    func set() {
+        value = true
+    }
+}
+
+extension ResponseHead {
+
+    fileprivate static let stub = ResponseHead(
+        url: nil,
+        status: .init(code: 200, reason: "OK"),
+        version: .init(minor: 1, major: 1),
+        headers: HTTPHeaders(),
+        isKeepAlive: false
+    )
+}
+
+extension Data {
+
+    fileprivate static let onePixelPNG = Data(
+        base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    )!
+}
+#endif

--- a/Tests/RequestDLTests/Image/Core/RDLImageLoaderTests.swift
+++ b/Tests/RequestDLTests/Image/Core/RDLImageLoaderTests.swift
@@ -1,0 +1,127 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Foundation
+import Testing
+
+@testable import RequestDL
+
+#if canImport(UIKit) || canImport(AppKit)
+struct RDLImageLoaderTests {
+
+    @Test
+    func decodesValidImageData() async throws {
+        // Given
+        let loader = RDLImageLoader()
+        let task = StubImageTask { .init(head: .stub, payload: .onePixelPNG) }
+
+        // When
+        let image = try await loader.load(id: "valid", task: task)
+
+        // Then
+        #expect(image.size.width > 0)
+        #expect(image.size.height > 0)
+    }
+
+    @Test
+    func throwsOnInvalidImageData() async throws {
+        // Given
+        let loader = RDLImageLoader()
+        let task = StubImageTask { .init(head: .stub, payload: Data("not an image".utf8)) }
+
+        // When/Then
+        do {
+            _ = try await loader.load(id: "invalid", task: task)
+            Issue.record("Expected RDLImageDecodingError")
+        } catch is RDLImageDecodingError {
+            // expected
+        }
+    }
+
+    @Test
+    func dedupesConcurrentLoadsForTheSameID() async throws {
+        // Given
+        let counter = Counter()
+
+        let task = StubImageTask {
+            await counter.increment()
+            try await Task.sleep(nanoseconds: 50_000_000)
+            return .init(head: .stub, payload: .onePixelPNG)
+        }
+
+        let loader = RDLImageLoader()
+
+        // When
+        async let first = loader.load(id: "shared", task: task)
+        async let second = loader.load(id: "shared", task: task)
+
+        let firstImage = try await first
+        let secondImage = try await second
+
+        // Then
+        #expect(firstImage.size == secondImage.size)
+        #expect(await counter.value == 1)
+    }
+
+    @Test
+    func doesNotDedupeAcrossDifferentIDs() async throws {
+        // Given
+        let counter = Counter()
+
+        let task = StubImageTask {
+            await counter.increment()
+            return .init(head: .stub, payload: .onePixelPNG)
+        }
+
+        let loader = RDLImageLoader()
+
+        // When
+        _ = try await loader.load(id: "first", task: task)
+        _ = try await loader.load(id: "second", task: task)
+
+        // Then
+        #expect(await counter.value == 2)
+    }
+}
+
+// MARK: - Test helpers
+
+private struct StubImageTask: RequestTask {
+
+    let onResult: @Sendable () async throws -> TaskResult<Data>
+
+    func result() async throws -> TaskResult<Data> {
+        try await onResult()
+    }
+}
+
+private actor Counter {
+
+    private(set) var value = 0
+
+    func increment() {
+        value += 1
+    }
+}
+
+extension ResponseHead {
+
+    fileprivate static let stub = ResponseHead(
+        url: nil,
+        status: .init(code: 200, reason: "OK"),
+        version: .init(minor: 1, major: 1),
+        headers: HTTPHeaders(),
+        isKeepAlive: false
+    )
+}
+
+extension Data {
+
+    /// A minimal, valid 1x1 transparent PNG, used to exercise real image decoding without
+    /// bundling a resource file.
+    fileprivate static let onePixelPNG = Data(
+        base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    )!
+}
+#endif

--- a/Tests/RequestDLTests/Image/Core/URLImagePropertyTests.swift
+++ b/Tests/RequestDLTests/Image/Core/URLImagePropertyTests.swift
@@ -1,0 +1,88 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Foundation
+import Testing
+
+@testable import RequestDL
+
+#if canImport(UIKit) || canImport(AppKit)
+struct URLImagePropertyTests {
+
+    @Test
+    func hostOnly() async throws {
+        // Given
+        let url = URL(string: "https://example.com")!
+
+        // When
+        let resolved = try await resolve(URLImageProperty(url: url))
+
+        // Then
+        #expect(resolved.requestConfiguration.url == "https://example.com")
+    }
+
+    @Test
+    func httpScheme() async throws {
+        // Given
+        let url = URL(string: "http://example.com")!
+
+        // When
+        let resolved = try await resolve(URLImageProperty(url: url))
+
+        // Then
+        #expect(resolved.requestConfiguration.url == "http://example.com")
+    }
+
+    @Test
+    func hostWithPort() async throws {
+        // Given
+        let url = URL(string: "https://example.com:8443/image.png")!
+
+        // When
+        let resolved = try await resolve(URLImageProperty(url: url))
+
+        // Then
+        #expect(resolved.requestConfiguration.url == "https://example.com:8443/image.png")
+    }
+
+    @Test
+    func hostWithPath() async throws {
+        // Given
+        let url = URL(string: "https://example.com/assets/avatar.png")!
+
+        // When
+        let resolved = try await resolve(URLImageProperty(url: url))
+
+        // Then
+        #expect(resolved.requestConfiguration.url == "https://example.com/assets/avatar.png")
+    }
+
+    @Test
+    func hostWithQuery() async throws {
+        // Given
+        let url = URL(string: "https://example.com/avatar?size=200&format=png")!
+
+        // When
+        let resolved = try await resolve(URLImageProperty(url: url))
+
+        // Then
+        #expect(resolved.requestConfiguration.url == "https://example.com/avatar?size=200&format=png")
+    }
+
+    @Test
+    func queryValuesAreNotDoubleEncoded() async throws {
+        // Given
+        // RequestConfiguration.queries is documented as expecting values that are already
+        // percent encoded. URLImageProperty must forward the URL's own encoding as-is instead
+        // of encoding it a second time, or "%20" here would come out as "%2520".
+        let url = URL(string: "https://example.com/avatar?name=John%20Doe")!
+
+        // When
+        let resolved = try await resolve(URLImageProperty(url: url))
+
+        // Then
+        #expect(resolved.requestConfiguration.url == "https://example.com/avatar?name=John%20Doe")
+    }
+}
+#endif

--- a/Tests/RequestDLTests/Image/SwiftUI/RDLImageInitTests.swift
+++ b/Tests/RequestDLTests/Image/SwiftUI/RDLImageInitTests.swift
@@ -3,12 +3,13 @@
 //
 
 import Foundation
-import SwiftUI
 import Testing
 
 @testable import RequestDL
 
 #if canImport(SwiftUI) && (canImport(UIKit) || canImport(AppKit))
+import SwiftUI
+
 /// `RDLImage` leans on `_ConditionalContent`-returning generic initializers to mirror
 /// `AsyncImage`'s API. That machinery is easy to break silently — the type still compiles, just
 /// against a narrower or looser signature than intended — so these tests exist to pin every

--- a/Tests/RequestDLTests/Image/SwiftUI/RDLImageInitTests.swift
+++ b/Tests/RequestDLTests/Image/SwiftUI/RDLImageInitTests.swift
@@ -1,0 +1,70 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Foundation
+import SwiftUI
+import Testing
+
+@testable import RequestDL
+
+#if canImport(SwiftUI) && (canImport(UIKit) || canImport(AppKit))
+/// `RDLImage` leans on `_ConditionalContent`-returning generic initializers to mirror
+/// `AsyncImage`'s API. That machinery is easy to break silently — the type still compiles, just
+/// against a narrower or looser signature than intended — so these tests exist to pin every
+/// public initializer's shape, not to exercise runtime loading behavior (already covered by
+/// `RDLImageLoaderTests`).
+@MainActor
+struct RDLImageInitTests {
+
+    private static let url = URL(string: "https://example.com/avatar.png")
+
+    @Test
+    func urlPhaseInit() {
+        // When
+        let view = RDLImage(url: Self.url) { (_: RDLImagePhase) in
+            EmptyView()
+        }
+
+        // Then
+        #expect(type(of: view) == RDLImage<EmptyView>.self)
+    }
+
+    @Test
+    func nilURLPhaseInit() {
+        // When
+        let view = RDLImage(url: nil) { (_: RDLImagePhase) in
+            EmptyView()
+        }
+
+        // Then
+        #expect(type(of: view) == RDLImage<EmptyView>.self)
+    }
+
+    @Test
+    func urlContentPlaceholderInit() {
+        // When/Then
+        _ = RDLImage(
+            url: Self.url,
+            content: { $0.resizable() },
+            placeholder: { ProgressView() }
+        )
+    }
+
+    @Test
+    func taskPhaseInit() {
+        // Given
+        // `Path` is qualified because `SwiftUI` also declares a `Path` type (the vector graphics
+        // one), and this file imports both.
+        let task = DataTask {
+            BaseURL("example.com")
+            RequestDL.Path("avatar.png")
+        }
+
+        // When/Then
+        _ = RDLImage(id: "avatar", task: task) { (_: RDLImagePhase) in
+            EmptyView()
+        }
+    }
+}
+#endif

--- a/Tests/RequestDLTests/Image/SwiftUI/RDLImagePhaseTests.swift
+++ b/Tests/RequestDLTests/Image/SwiftUI/RDLImagePhaseTests.swift
@@ -2,12 +2,13 @@
 // See LICENSE for this package's licensing information.
 //
 
-import SwiftUI
 import Testing
 
 @testable import RequestDL
 
 #if canImport(SwiftUI) && (canImport(UIKit) || canImport(AppKit))
+import SwiftUI
+
 @MainActor
 struct RDLImagePhaseTests {
 

--- a/Tests/RequestDLTests/Image/SwiftUI/RDLImagePhaseTests.swift
+++ b/Tests/RequestDLTests/Image/SwiftUI/RDLImagePhaseTests.swift
@@ -1,0 +1,46 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import SwiftUI
+import Testing
+
+@testable import RequestDL
+
+#if canImport(SwiftUI) && (canImport(UIKit) || canImport(AppKit))
+@MainActor
+struct RDLImagePhaseTests {
+
+    private struct StubError: Error {}
+
+    @Test
+    func emptyPhaseHasNoImageOrError() {
+        // Given
+        let phase = RDLImagePhase.empty
+
+        // Then
+        #expect(phase.image == nil)
+        #expect(phase.error == nil)
+    }
+
+    @Test
+    func successPhaseExposesItsImage() {
+        // Given
+        let phase = RDLImagePhase.success(Image(systemName: "photo"))
+
+        // Then
+        #expect(phase.image != nil)
+        #expect(phase.error == nil)
+    }
+
+    @Test
+    func failurePhaseExposesItsError() {
+        // Given
+        let phase = RDLImagePhase.failure(StubError())
+
+        // Then
+        #expect(phase.image == nil)
+        #expect(phase.error is StubError)
+    }
+}
+#endif

--- a/Tests/RequestDLTests/Image/UIKit/UIImageViewRequestDLTests.swift
+++ b/Tests/RequestDLTests/Image/UIKit/UIImageViewRequestDLTests.swift
@@ -1,0 +1,149 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Foundation
+import SwiftAsyncStream
+import Testing
+
+@testable import RequestDL
+
+#if canImport(UIKit) && !os(watchOS)
+import UIKit
+
+@MainActor
+struct UIImageViewRequestDLTests {
+
+    @Test
+    func setImageAppliesTheLoadedImage() async throws {
+        // Given
+        let imageView = UIImageView()
+        let signal = AsyncSignal()
+
+        // When
+        imageView.rdl.setImage(id: "one", task: StubImageTask { .init(head: .stub, payload: .onePixelPNG) }) { _ in
+            signal.signal()
+        }
+        try await signal.wait()
+
+        // Then
+        #expect(imageView.image != nil)
+    }
+
+    @Test
+    func placeholderIsAppliedImmediately() {
+        // Given
+        let imageView = UIImageView()
+        let placeholder = UIImage()
+
+        // When
+        imageView.rdl.setImage(
+            id: "slow",
+            task: StubImageTask {
+                try await Task.sleep(nanoseconds: 200_000_000)
+                return .init(head: .stub, payload: .onePixelPNG)
+            },
+            placeholder: placeholder
+        )
+
+        // Then
+        #expect(imageView.image === placeholder)
+        imageView.rdl.cancel()
+    }
+
+    @Test
+    func reusingTheImageViewCancelsThePreviousLoad() async throws {
+        // Given
+        let imageView = UIImageView()
+        let firstCompleted = Flag()
+        let secondSignal = AsyncSignal()
+
+        // When
+        imageView.rdl.setImage(
+            id: "first",
+            task: StubImageTask {
+                try await Task.sleep(nanoseconds: 300_000_000)
+                return .init(head: .stub, payload: .onePixelPNG)
+            }
+        ) { _ in
+            Task { await firstCompleted.set() }
+        }
+
+        imageView.rdl.setImage(id: "second", task: StubImageTask { .init(head: .stub, payload: .onePixelPNG) }) { _ in
+            secondSignal.signal()
+        }
+
+        try await secondSignal.wait()
+
+        // Give the first task's sleep enough time to also finish, to prove its completion never
+        // fires once superseded.
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        // Then
+        #expect(await !firstCompleted.value)
+        #expect(imageView.image != nil)
+    }
+
+    @Test
+    func cancelStopsThePendingLoad() async throws {
+        // Given
+        let imageView = UIImageView()
+        let completed = Flag()
+
+        // When
+        imageView.rdl.setImage(
+            id: "cancel-me",
+            task: StubImageTask {
+                try await Task.sleep(nanoseconds: 200_000_000)
+                return .init(head: .stub, payload: .onePixelPNG)
+            }
+        ) { _ in
+            Task { await completed.set() }
+        }
+        imageView.rdl.cancel()
+
+        try await Task.sleep(nanoseconds: 400_000_000)
+
+        // Then
+        #expect(await !completed.value)
+    }
+}
+
+// MARK: - Test helpers
+
+private struct StubImageTask: RequestTask {
+
+    let onResult: @Sendable () async throws -> TaskResult<Data>
+
+    func result() async throws -> TaskResult<Data> {
+        try await onResult()
+    }
+}
+
+private actor Flag {
+
+    private(set) var value = false
+
+    func set() {
+        value = true
+    }
+}
+
+extension ResponseHead {
+
+    fileprivate static let stub = ResponseHead(
+        url: nil,
+        status: .init(code: 200, reason: "OK"),
+        version: .init(minor: 1, major: 1),
+        headers: HTTPHeaders(),
+        isKeepAlive: false
+    )
+}
+
+extension Data {
+
+    fileprivate static let onePixelPNG = Data(
+        base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    )!
+}
+#endif


### PR DESCRIPTION
## Summary

Adds an `AsyncImage`-equivalent image loading API built on RequestDL's own request pipeline and cache, instead of a separate one:

- **`RDLImageLoader`** — the shared engine. Wraps any `RequestTask<TaskResult<Data>>` (`DataTask`, `MockedTask`, ...), decodes it into a `PlatformImage`, and dedupes concurrent loads that share the same identifier — N callers asking for the same image at once trigger one download, not N.
- **`RDLImage`** — a SwiftUI view mirroring `AsyncImage`'s URL-based and phase-based initializers, plus a `task:`-based one for requests that need more than a URL (headers, auth, `cachePolicy`/`cacheStrategy`, etc.).
- **`UIImageView.rdl` / `NSImageView.rdl` / `WKInterfaceImage.rdl`** — the same loading surface on UIKit, AppKit and watchOS, namespaced through `RDLWrapper`/`RDLCompatible` so it doesn't add members directly to those types. Every call cancels any load already in flight on that image view first, which is what makes it safe to call from a reused table/collection view cell.

Also fixes three pre-existing broken DocC symbol links (`SSLPSKIdentityResolver`, `SSLKeyLogger`, `AlreadyConsumedError`) found while verifying the new documentation built clean.

## Test plan

- [x] `swift test` — 1126 tests passing on macOS (AppKit path)
- [x] `xcodebuild build` for iOS Simulator and tvOS Simulator (UIKit path) — clean
- [x] `xcodebuild test` for iOS Simulator — new `UIImageView` tests passing (load, placeholder, reuse cancellation, explicit cancel)
- [x] `xcodebuild build` + `xcodebuild test` for watchOS Simulator (`WKInterfaceImage` path) — clean build; full suite passes (this type can't be instantiated directly in a unit test — `WKInterfaceObject.init()` is `NS_UNAVAILABLE` — so its logic is covered indirectly via the shared loader and the UIKit/AppKit tests)
- [x] `xcodebuild docbuild` — new "Loading images" DocC article resolves with zero diagnostics; confirmed the 3 pre-existing warnings are also gone
- [x] `swift-format lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)