### PR TITLE
Fix Internals.URLSessionClient crashing under load on iOS Simulator

### DIFF
--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Internals.URLSessionClient.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Internals.URLSessionClient.swift
@@ -123,6 +123,11 @@ extension Internals {
         /// caught by `execute_whenRedirectChainExceedsMax_throwsRedirectLimitReachedError`, which
         /// started failing with `MissingURLResponseError` instead of the expected
         /// `RedirectLimitReachedError` once a redirect was actually refused.)
+        ///
+        /// `session.data(for:delegate:)` also cancelled its underlying `URLSessionTask`
+        /// automatically when the awaiting Swift `Task` was cancelled -- a guarantee this hand
+        /// bridge has to restore explicitly, via `CancellableTaskBox`, since nothing does that for
+        /// a bare `withCheckedThrowingContinuation` on its own.
         package func execute(
             request: URLRequest,
             delegate: URLSessionTaskDelegate? = nil
@@ -148,12 +153,19 @@ extension Internals {
                 forwarding: delegate
             )
 
-            return try await withCheckedThrowingContinuation { continuation in
-                taskDelegate.completion = { continuation.resume(with: $0) }
+            let box = CancellableTaskBox()
 
-                let task = session.dataTask(with: request)
-                task.delegate = taskDelegate
-                task.resume()
+            return try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    taskDelegate.completion = { continuation.resume(with: $0) }
+
+                    let task = session.dataTask(with: request)
+                    task.delegate = taskDelegate
+                    box.task = task
+                    task.resume()
+                }
+            } onCancel: {
+                box.cancel()
             }
         }
 
@@ -539,6 +551,41 @@ extension Internals.URLSessionClient {
     /// `Internals.RedirectConfiguration.follow(_:allowCycles:)`'s `allowCycles` is `false`.
     /// Mirrors `HTTPClientError.redirectCycleDetected` from the NIO executor.
     package struct RedirectCycleDetectedError: Error, Sendable {}
+
+    /// Lets a `withTaskCancellationHandler`'s `onCancel` closure reach a `URLSessionTask` that a
+    /// concurrently-running `operation` closure is still in the middle of creating.
+    ///
+    /// `onCancel` can fire the instant cancellation is requested -- including strictly before
+    /// `operation` ever assigns `task` -- so a plain `URLSessionTask?` written to after the fact
+    /// could miss a cancellation that arrived in that gap. `task`'s setter checks for exactly that
+    /// ordering and cancels immediately instead of losing it.
+    fileprivate final class CancellableTaskBox: @unchecked Sendable {
+
+        private let lock = Lock()
+        private var _task: URLSessionTask?
+        private var _isCancelled = false
+
+        var task: URLSessionTask? {
+            get { lock.withLock { _task } }
+            set {
+                let shouldCancelImmediately = lock.withLock {
+                    _task = newValue
+                    return _isCancelled
+                }
+                if shouldCancelImmediately {
+                    newValue?.cancel()
+                }
+            }
+        }
+
+        func cancel() {
+            let task = lock.withLock {
+                _isCancelled = true
+                return _task
+            }
+            task?.cancel()
+        }
+    }
 }
 
 /// `Internals.URLSessionClient`'s own per-request delegate: redirect enforcement, proxy

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Internals.URLSessionClient.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Internals.URLSessionClient.swift
@@ -104,6 +104,25 @@ extension Internals {
         /// the server-trust/client-certificate challenge (see `TaskDelegate` below) all run
         /// regardless of `delegate`; `delegate` is only consulted for a TLS challenge this client
         /// has no `identityPolicy` to answer.
+        ///
+        /// Deliberately not `session.data(for:request:delegate:)` -- a captured crash report
+        /// (`EXC_BREAKPOINT`/`SIGTRAP`, entirely inside Foundation's own
+        /// `NSURLSession.data(for:delegate:)` closures on the `com.apple.NSURLSession-work`
+        /// queue, no frame of this package's own code anywhere in the crashing thread) confirms a
+        /// real, if rare, bug in that bridge -- reproducible on an iOS Simulator under heavy
+        /// concurrent test load, not this package's own delegate (`TaskDelegate`'s shared state
+        /// is already lock-protected). Bridged by hand instead, the same way the streamed-upload
+        /// overload below already does: build a plain `dataTask(with:)` with no completion
+        /// handler of its own, so `TaskDelegate` (already `URLSessionDataDelegate`-conforming) is
+        /// the *only* thing consuming the response/data, and let its own
+        /// `didCompleteWithError:` -- which already knows how to turn `redirectError`/the
+        /// accumulated response into exactly this method's return shape -- resolve `completion`
+        /// once the task finishes. (An earlier version of this fix instead read `data`/`response`
+        /// off a `dataTask(with:completionHandler:)` completion handler directly, alongside the
+        /// same delegate -- reachable together, but not guaranteed to agree with each other:
+        /// caught by `execute_whenRedirectChainExceedsMax_throwsRedirectLimitReachedError`, which
+        /// started failing with `MissingURLResponseError` instead of the expected
+        /// `RedirectLimitReachedError` once a redirect was actually refused.)
         package func execute(
             request: URLRequest,
             delegate: URLSessionTaskDelegate? = nil
@@ -129,25 +148,13 @@ extension Internals {
                 forwarding: delegate
             )
 
-            let (data, response) = try await session.data(for: request, delegate: taskDelegate)
+            return try await withCheckedThrowingContinuation { continuation in
+                taskDelegate.completion = { continuation.resume(with: $0) }
 
-            // A refused redirect does not fail `data(for:delegate:)` itself -- URLSession has no
-            // API for a redirect delegate callback to fail the task with a caller-supplied error,
-            // only to stop following (`completionHandler(nil)`), which completes the task
-            // successfully with the redirect response as final. `redirectError` is how the
-            // delegate reports that refusal back here, so it can be surfaced the same way
-            // AsyncHTTPClient surfaces `HTTPClientError.redirectLimitReached`/
-            // `.redirectCycleDetected`: failing the whole request, not returning a truncated
-            // response.
-            if let redirectError = taskDelegate.redirectError {
-                throw redirectError
+                let task = session.dataTask(with: request)
+                task.delegate = taskDelegate
+                task.resume()
             }
-
-            guard let httpResponse = response as? HTTPURLResponse else {
-                throw UnexpectedURLResponseError(response: response)
-            }
-
-            return (Internals.ResponseHead(httpResponse), data)
         }
 
         /// Executes `request` with a body drained from `body` rather than buffered into `Data` up

--- a/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/InternalsURLSessionClientTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/InternalsURLSessionClientTests.swift
@@ -82,6 +82,45 @@ struct InternalsURLSessionClientTests {
         let decoded = try JSONDecoder().decode(HTTPResult<String>.self, from: result.body)
         #expect(decoded.response == output)
     }
+
+    /// `execute(request:delegate:)` bridges `dataTask(with:)` to `async`/`await` by hand
+    /// (`session.data(for:delegate:)` has a confirmed crash under load -- see the method's own
+    /// doc comment) -- unlike that Foundation API, nothing cancels the underlying
+    /// `URLSessionTask` for free just because the awaiting Swift `Task` was cancelled. This
+    /// confirms `CancellableTaskBox` actually restores that: cancelling the caller's `Task` both
+    /// makes the call throw and stops the real network request, not just the first of the two.
+    @Test
+    func execute_whenTaskCancelledMidFlight_cancelsUnderlyingURLSessionTaskAndThrows() async throws {
+        try await withHangingServer { port in
+            let client = try Internals.URLSessionClient(configuration: .ephemeral)
+            let url = try #require(URL(string: "http://127.0.0.1:\(port)/"))
+
+            let responseTask = _Concurrency.Task {
+                try await client.execute(request: URLRequest(url: url))
+            }
+
+            // Gives the request a moment to actually reach the (unresponsive) server before
+            // cancelling, so this exercises a genuine in-flight cancellation rather than one
+            // that races the connection attempt itself.
+            try await _Concurrency.Task.sleep(nanoseconds: 200_000_000)
+            #expect(client.isRunning)
+
+            responseTask.cancel()
+
+            await #expect(throws: (any Error).self) {
+                _ = try await responseTask.value
+            }
+
+            // `didCompleteWithError:` releases the operation-queue slot asynchronously, so poll
+            // briefly rather than asserting immediately after `cancel()` returns.
+            var stillRunning = client.isRunning
+            for _ in 0..<50 where stillRunning {
+                try await _Concurrency.Task.sleep(nanoseconds: 20_000_000)
+                stillRunning = client.isRunning
+            }
+            #expect(!stillRunning)
+        }
+    }
 }
 
 /// Test-only stand-in for the real client's own TLS challenge handling -- see the identical


### PR DESCRIPTION
## Summary

- `Internals.URLSessionClient.execute(request:delegate:)` (the buffered, non-streaming request/response path) used `session.data(for:request:delegate:)`, Foundation's own `async`/`await` bridge for `URLSession`. A captured crash report (`EXC_BREAKPOINT`/`SIGTRAP`, entirely inside Foundation's own `NSURLSession.data(for:delegate:)` closures on the `com.apple.NSURLSession-work` queue — no frame of this package's own code anywhere in the crashing thread) confirms a real, if rare, bug in that bridge. Reproducible running the full `RequestDLInternalsTests` suite on an iOS Simulator under swift-testing's default concurrent parallelism — this is the previously-tracked known issue against `InternalsURLSessionClientRedirectTests`, root-caused for the first time here rather than left as "probably resource contention."
- Not a defect in this package's own delegate: `TaskDelegate`'s shared state is already lock-protected, and every crashing thread's stack lives entirely inside Foundation's private frames.
- Fix: bridge the call by hand instead, mirroring the streamed-upload overload already in this same file — a plain `dataTask(with:)` with **no** completion handler of its own, so `TaskDelegate` (already `URLSessionDataDelegate`-conforming) is the *only* thing consuming the response/data, resolved through its existing `didCompleteWithError:` handling once the task finishes.
- A first attempt at this fix read `data`/`response` off a `dataTask(with:completionHandler:)` completion handler directly, reachable alongside the same delegate but not guaranteed to agree with it — caught by `execute_whenRedirectChainExceedsMax_throwsRedirectLimitReachedError`, which started failing with `MissingURLResponseError` instead of the expected `RedirectLimitReachedError` once a redirect was actually refused. The final fix avoids the dual-mechanism entirely.
- **Cancellation, restored explicitly.** `session.data(for:delegate:)` also cancelled its underlying `URLSessionTask` automatically when the awaiting Swift `Task` was cancelled — the hand-written bridge above doesn't get that for free. Added back via `withTaskCancellationHandler` + a small `CancellableTaskBox` (handles `onCancel` firing before the task is even created, under load). New regression test (`execute_whenTaskCancelledMidFlight_cancelsUnderlyingURLSessionTaskAndThrows`) confirms both halves — the call throws, and the underlying task actually stops — through a real in-flight cancellation; confirmed non-tautological by temporarily reverting the cancellation handler and watching the same test hang indefinitely instead of failing fast.

## Test plan
- [x] `swift build` — clean
- [x] `swift test` (macOS) — full suite (840 + 423 tests) passes, same known-issue baseline as `feature/urlsession-executor`
- [x] `swift format lint --strict` — clean
- [x] **21 consecutive iOS Simulator runs across two validation rounds**, under the exact conditions that originally reproduced the crash (swift-testing's default concurrent parallelism): 11 for the data-delivery fix (10 isolated `RequestDLInternalsTests` runs + 1 full-scheme run), 10 more after adding cancellation support (9 clean, 1 unrelated pre-existing flaky failure in a NIO-only concurrency test with no `URLSessionClient` involvement). Zero crashes across all 21. For comparison: the pre-fix code crashed on the 3rd of 5 such runs during this investigation, with a captured `.ips` crash report confirming the root cause above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)